### PR TITLE
Initial support for literal and interpolated strings

### DIFF
--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -96,10 +96,13 @@ Ident ::= IdentComp
 Literal ::= LitNumber
           | LitArray
           | LitHash
+          | LitString
+          | InterpolString
 
-LitArray ::= LBracket Expression RBracket
-
-LitHash ::= LBrace Expression RBrace
+LitArray       ::= LBracket Expression RBracket
+LitHash        ::= LBrace Expression RBrace
+LitString      ::= SingleQuote NonSingleQuote SingleQuote
+InterpolString ::= DoubleQuote NonDoubleQuote DoubleQuote
 
 ArrowRHS ::= ArrowDerefCall
            | ArrowMethodCall
@@ -813,7 +816,11 @@ OpKeywordWriteExpr            ::= OpKeywordWrite Expression
 IdentComp  ~ [a-zA-Z_]+
 PackageSep ~ '::'
 
-LitNumber ~ [0-9]+
+LitNumber      ~ [0-9]+
+SingleQuote    ~ [']
+DoubleQuote    ~ ["]
+NonDoubleQuote ~ [^"]+
+NonSingleQuote ~ [^']+
 
 Colon     ~ ':'
 Semicolon ~ ';'


### PR DESCRIPTION
This expects GH #4 to be merged first.

This does **not** handle escaping. I found a bunch of examples but they all require time to understand so I put in initial support first.

This also won't support crazy stuff like:

```perl
"string with @{[ expression() . "this other string" ]} rest of string"
```

I'm okay with this never being supported.