### PR TITLE
Add for/while/until loops

### DIFF
--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -39,7 +39,6 @@ StatementModifier ::= ConditionIfPostfixExpr
                     | ConditionUntilPostfixExpr
                     | ConditionForPostfixExpr
                     | ConditionForeachPostfixExpr
-                    | ConditionWhenPostfixExpr
 
 Condition ::= ConditionIfExpr ConditionElsifExpr ConditionElseExpr
             | ConditionIfExpr ConditionElseExpr
@@ -58,7 +57,6 @@ ConditionWhilePostfixExpr   ::= ConditionWhile   Expression
 ConditionUntilPostfixExpr   ::= ConditionUntil   Expression
 ConditionForPostfixExpr     ::= ConditionFor     Expression
 ConditionForeachPostfixExpr ::= ConditionForeach Expression
-ConditionWhenPostfixExpr    ::= ConditionWhen    Expression
 
 Label ::= IdentComp Colon
 
@@ -1280,7 +1278,6 @@ ConditionWhile   ~ 'while'
 ConditionUntil   ~ 'until'
 ConditionFor     ~ 'for'
 ConditionForeach ~ 'foreach'
-ConditionWhen    ~ 'when'
 
 # These are some parsing rules for the Expressions for them:
 # ----

--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -15,8 +15,16 @@ StatementSeq ::= Statement
 
 Statement ::= NonBraceExpression StatementModifier
             | NonBraceExpression
+            | ForStatement
             | Block
             | Condition
+
+ForStatement ::= ForStatementOp LParen Statement Semicolon Statement Semicolon Statement RParen Block
+               | ForStatementOp OpKeywordMy VarScalar LParen Expression RParen Block
+               | ForStatementOp VarScalar LParen Expression RParen Block
+
+ForStatementOp ::= OpKeywordFor
+                 | OpKeywordForeach
 
 StatementModifier ::= ConditionIfPostfixExpr
                     | ConditionUnlessPostfixExpr
@@ -1057,6 +1065,8 @@ OpKeywordExists           ~ 'exists'
 OpKeywordExit             ~ 'exit'
 OpKeywordExp              ~ 'exp'
 OpKeywordFc               ~ 'fc'
+OpKeywordFor              ~ 'for'
+OpKeywordForeach          ~ 'foreach'
 OpKeywordFcntl            ~ 'fcntl'
 OpKeywordFileno           ~ 'fileno'
 OpKeywordFlock            ~ 'flock'

--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -15,9 +15,13 @@ StatementSeq ::= Statement
 
 Statement ::= NonBraceExpression StatementModifier
             | NonBraceExpression
-            | ForStatement
+            | LoopStatement
             | Block
             | Condition
+
+LoopStatement ::= ForStatement
+                | WhileStatement
+                | UntilStatement
 
 ForStatement ::= ForStatementOp LParen Statement Semicolon Statement Semicolon Statement RParen Block
                | ForStatementOp OpKeywordMy VarScalar LParen Expression RParen Block
@@ -25,6 +29,9 @@ ForStatement ::= ForStatementOp LParen Statement Semicolon Statement Semicolon S
 
 ForStatementOp ::= OpKeywordFor
                  | OpKeywordForeach
+
+WhileStatement ::= ConditionWhile LParen Expression RParen Block
+UntilStatement ::= ConditionUntil LParen Expression RParen Block
 
 StatementModifier ::= ConditionIfPostfixExpr
                     | ConditionUnlessPostfixExpr


### PR DESCRIPTION
[This includes the commits from #15 and needs to be rebased before it's merged.]

This adds:

```perl
foreach my $foo (@bar) {...}
foreach $foo (@bar) {...}
foreach (@bar) {...}

while ( EXPR ) {...}
until ( EXPR ) {...}
```

Postfix of these is provided by #15.

After this MR, I want to cleanup the `while`/`until` from being under a ConditionOp to be a KeywordOp.