### PR TITLE
WIP: Preliminary support for q, qq, qw, qx, qr

### DIFF
--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -807,7 +807,7 @@ OpKeywordSocketpairExpr       ::= OpKeywordSocketpair Expression OpComma Express
 OpKeywordSortExpr             ::= OpKeywordSort Block Expression
                                 | OpKeywordSort NonBraceExpression Expression
                                 | OpKeywordSort VarScalar Expression
-                                | OpKeywordSort Expression
+                                | OpKeywordSort NonBraceExpression
 
 OpKeywordSpliceExpr           ::= OpKeywordSplice Expression OpComma Expression OpComma Expression OpComma Expression
                                 | OpKeywordSplice Expression OpComma Expression OpComma Expression

--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -13,7 +13,7 @@ StatementSeq ::= Statement
                | Statement Semicolon
                | Statement Semicolon StatementSeq
 
-Statement ::= Expression
+Statement ::= NonBraceExpression
             | Block
 
 Label ::= IdentComp Colon
@@ -44,12 +44,44 @@ Expression ::= Value
             || Expression OpNameAnd Expression assoc=>left
             || Expression OpNameOr Expression  assoc=>left
 
-Value ::= Literal
-        | Variable
-        | UnderscoreValues
-        | SubCall
-        | OpKeywordDoExpr
-        | LParen Expression RParen
+# Same as Expression, but since it's a top-level expresison,
+# it can only use NonBraceValue and NonBraceExpressions
+NonBraceExpression ::= NonBraceValue
+                    || NonBraceExpression OpArrow ArrowRHS     assoc=>left
+                    || NonBraceExpression OpInc
+                    || OpInc Expression
+                    || NonBraceExpression OpPower Expression   assoc=>right
+                    || OpUnary Expression                      assoc=>right
+                    || NonBraceExpression OpRegex Expression   assoc=>left
+                    || NonBraceExpression OpMulti Expression   assoc=>left
+                    || NonBraceExpression OpAdd Expression     assoc=>left
+                    || NonBraceExpression OpShift Expression   assoc=>left
+                    || OpKeyword
+                    || NonBraceExpression OpInequal Expression
+                    || NonBraceExpression OpEqual Expression
+                    || NonBraceExpression OpBinAnd Expression  assoc=>left
+                    || NonBraceExpression OpBinOr Expression   assoc=>left
+                    || NonBraceExpression OpLogAnd Expression  assoc=>left
+                    || NonBraceExpression OpLogOr Expression   assoc=>left
+                    || NonBraceExpression OpRange Expression
+                    || NonBraceExpression OpTriThen Expression OpTriElse Expression  assoc=>right
+                    || NonBraceExpression OpAssign Expression  assoc=>right
+                    || OpNameNot Expression                    assoc=>right
+                    || NonBraceExpression OpNameAnd Expression assoc=>left
+                    || NonBraceExpression OpNameOr Expression  assoc=>left
+
+Value         ::= Literal
+                | Variable
+                | UnderscoreValues
+                | SubCall
+                | LParen Expression RParen
+
+# Same as Value above, but with a NonBraceLiteral
+NonBraceValue ::= NonBraceLiteral
+                | Variable
+                | UnderscoreValues
+                | SubCall
+                | LParen Expression RParen
 
 # UnderscoreData and UnderscoreEnd are not values
 UnderscoreValues ::= UnderscorePackage
@@ -94,11 +126,13 @@ Ident ::= IdentComp
         | IdentComp PackageSep Ident
         | Ident PackageSep
 
-Literal ::= LitNumber
-          | LitArray
-          | LitHash
-          | LitString
-          | InterpolString
+NonBraceLiteral ::= LitNumber
+                  | LitArray
+                  | LitString
+                  | InterpolString
+
+Literal         ::= NonBraceLiteral
+                  | LitHash
 
 LitArray       ::= LBracket Expression RBracket
 LitHash        ::= LBrace Expression RBrace

--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -13,11 +13,18 @@ StatementSeq ::= Statement
                | Statement Semicolon
                | Statement Semicolon StatementSeq
 
-Statement ::= NonBraceExpression ConditionIfPostfixExpr
-            | NonBraceExpression ConditionUnlessPostfixExpr
+Statement ::= NonBraceExpression StatementModifier
             | NonBraceExpression
             | Block
             | Condition
+
+StatementModifier ::= ConditionIfPostfixExpr
+                    | ConditionUnlessPostfixExpr
+                    | ConditionWhilePostfixExpr
+                    | ConditionUntilPostfixExpr
+                    | ConditionForPostfixExpr
+                    | ConditionForeachPostfixExpr
+                    | ConditionWhenPostfixExpr
 
 Condition ::= ConditionIfExpr ConditionElsifExpr ConditionElseExpr
             | ConditionIfExpr ConditionElseExpr
@@ -25,12 +32,17 @@ Condition ::= ConditionIfExpr ConditionElsifExpr ConditionElseExpr
             | ConditionIfExpr
             | ConditionUnlessExpr
 
-ConditionUnlessExpr        ::= ConditionUnless LParen Expression RParen Block
-ConditionIfExpr            ::= ConditionIf     LParen Expression RParen Block
-ConditionElsifExpr         ::= ConditionElsif  LParen Expression RParen Block
-ConditionElseExpr          ::= ConditionElse   Block
-ConditionIfPostfixExpr     ::= ConditionIf     Expression
-ConditionUnlessPostfixExpr ::= ConditionUnless Expression
+ConditionUnlessExpr         ::= ConditionUnless  LParen Expression RParen Block
+ConditionIfExpr             ::= ConditionIf      LParen Expression RParen Block
+ConditionElsifExpr          ::= ConditionElsif   LParen Expression RParen Block
+ConditionElseExpr           ::= ConditionElse    Block
+ConditionIfPostfixExpr      ::= ConditionIf      Expression
+ConditionUnlessPostfixExpr  ::= ConditionUnless  Expression
+ConditionWhilePostfixExpr   ::= ConditionWhile   Expression
+ConditionUntilPostfixExpr   ::= ConditionUntil   Expression
+ConditionForPostfixExpr     ::= ConditionFor     Expression
+ConditionForeachPostfixExpr ::= ConditionForeach Expression
+ConditionWhenPostfixExpr    ::= ConditionWhen    Expression
 
 Label ::= IdentComp Colon
 
@@ -1250,10 +1262,15 @@ OpFileStartTime             ~ '-M'
 OpFileAccessTime            ~ '-A'
 OpFileChangeTime            ~ '-C'
 
-ConditionIf     ~ 'if'
-ConditionElsif  ~ 'elsif'
-ConditionElse   ~ 'else'
-ConditionUnless ~ 'unless'
+ConditionIf      ~ 'if'
+ConditionElsif   ~ 'elsif'
+ConditionElse    ~ 'else'
+ConditionUnless  ~ 'unless'
+ConditionWhile   ~ 'while'
+ConditionUntil   ~ 'until'
+ConditionFor     ~ 'for'
+ConditionForeach ~ 'foreach'
+ConditionWhen    ~ 'when'
 
 # These are some parsing rules for the Expressions for them:
 # ----

--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -320,6 +320,7 @@ OpKeyword ::= OpKeywordAbsExpr
             | OpKeywordSleepExpr
             | OpKeywordSocketExpr
             | OpKeywordSocketpairExpr
+            | OpKeywordSortExpr
             | OpKeywordSpliceExpr
             | OpKeywordSprintfExpr
             | OpKeywordSqrtExpr
@@ -363,7 +364,6 @@ OpKeyword ::= OpKeywordAbsExpr
 #| OpKeywordNoExpr
 #| OpKeywordPackageExpr
 #| OpKeywordRequireExpr
-#| OpKeywordSortExpr
 #| OpKeywordSplitExpr
 #| OpKeywordSubExpr
 #| OpKeywordUseExpr
@@ -804,6 +804,11 @@ OpKeywordSocketExpr           ::= OpKeywordSocket Expression OpComma Expression 
 
 OpKeywordSocketpairExpr       ::= OpKeywordSocketpair Expression OpComma Expression OpComma Expression OpComma Expression OpComma Expression
 
+OpKeywordSortExpr             ::= OpKeywordSort Block Expression
+                                | OpKeywordSort NonBraceExpression Expression
+                                | OpKeywordSort VarScalar Expression
+                                | OpKeywordSort Expression
+
 OpKeywordSpliceExpr           ::= OpKeywordSplice Expression OpComma Expression OpComma Expression OpComma Expression
                                 | OpKeywordSplice Expression OpComma Expression OpComma Expression
                                 | OpKeywordSplice Expression OpComma Expression
@@ -1158,7 +1163,7 @@ OpKeywordSin              ~ 'sin'
 OpKeywordSleep            ~ 'sleep'
 OpKeywordSocket           ~ 'socket'
 OpKeywordSocketpair       ~ 'socketpair'
-# TODO: OpKeywordSort             ~ 'sort'
+OpKeywordSort             ~ 'sort'
 OpKeywordSplice           ~ 'splice'
 # TODO: OpKeywordSplit            ~ 'split'
 OpKeywordSprintf          ~ 'sprintf'

--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -328,6 +328,11 @@ OpKeyword ::= OpKeywordAbsExpr
             | OpKeywordPrintfExpr
             | OpKeywordPrototypeExpr
             | OpKeywordPushExpr
+            | OpKeywordQExpr
+            | OpKeywordQqExpr
+            | OpKeywordQxExpr
+            | OpKeywordQwExpr
+            | OpKeywordQrExpr
             | OpKeywordQuotemetaExpr
             | OpKeywordRandExpr
             | OpKeywordReadExpr
@@ -750,6 +755,12 @@ OpKeywordPrototypeExpr        ::= OpKeywordPrototype Expression
 
 OpKeywordPushExpr             ::= OpKeywordPush Expression OpComma Expression
 
+OpKeywordQExpr                ::= OpKeywordQ  QFuncDelimitedValue
+OpKeywordQqExpr               ::= OpKeywordQq QFuncDelimitedValue
+OpKeywordQxExpr               ::= OpKeywordQx QFuncDelimitedValue
+OpKeywordQwExpr               ::= OpKeywordQw QFuncDelimitedValue
+OpKeywordQrExpr               ::= OpKeywordQr QFuncDelimitedValue
+
 OpKeywordQuotemetaExpr        ::= OpKeywordQuotemeta Expression
                                 | OpKeywordQuotemeta
 
@@ -988,6 +999,19 @@ OpFileStartTimeExpr             ::= OpFileStartTime            Expression
 OpFileAccessTimeExpr            ::= OpFileAccessTime           Expression
 OpFileChangeTimeExpr            ::= OpFileChangeTime           Expression
 
+QFuncDelimitedValue ::= LParen       NonRParen       RParen
+                      | LParen       RParen
+                      | LBrace       NonRBrace       RBrace
+                      | LBrace       RBrace
+                      | LAngle       NonRAngle       RAngle
+                      | LAngle       RAngle
+                      | LBracket     NonRBracket     RBracket
+                      | LBracket     RBracket
+                      | ForwardSlash NonForwardSlash ForwardSlash
+                      | ForwardSlash ForwardSlash
+                      | ExclamPoint  NonExclamPoint  ExclamPoint
+                      | ExclamPoint  ExclamPoint
+
 ###
 
 IdentComp  ~ [a-zA-Z_]+
@@ -999,8 +1023,10 @@ DoubleQuote    ~ ["]
 NonDoubleQuote ~ [^"]+
 NonSingleQuote ~ [^']+
 
-Colon     ~ ':'
-Semicolon ~ ';'
+Colon        ~ ':'
+Semicolon    ~ ';'
+ForwardSlash ~ '/'
+ExclamPoint  ~ '!'
 
 SigilScalar   ~ '$'
 SigilArray    ~ '@'
@@ -1015,6 +1041,15 @@ LBracket ~ '['
 RBracket ~ ']'
 LBrace   ~ '{'
 RBrace   ~ '}'
+LAngle   ~ '<'
+RAngle   ~ '>'
+
+NonRParen       ~ [^)]+
+NonRBracket     ~ [^\]]+
+NonRBrace       ~ [^\}]+
+NonRAngle       ~ [^>]+
+NonForwardSlash ~ [^\/]+
+NonExclamPoint  ~ [^\!]+
 
 Ellipsis ~ '...'
 
@@ -1174,6 +1209,11 @@ OpKeywordPrint            ~ 'print'
 OpKeywordPrintf           ~ 'printf'
 OpKeywordPrototype        ~ 'prototype'
 OpKeywordPush             ~ 'push'
+OpKeywordQ                ~ 'q'
+OpKeywordQq               ~ 'qq'
+OpKeywordQx               ~ 'qx'
+OpKeywordQw               ~ 'qw'
+OpKeywordQr               ~ 'qr'
 OpKeywordQuotemeta        ~ 'quotemeta'
 OpKeywordRand             ~ 'rand'
 OpKeywordRead             ~ 'read'

--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -34,7 +34,8 @@ Condition ::= ConditionIfExpr ConditionElsifExpr ConditionElseExpr
 
 ConditionUnlessExpr         ::= ConditionUnless  LParen Expression RParen Block
 ConditionIfExpr             ::= ConditionIf      LParen Expression RParen Block
-ConditionElsifExpr          ::= ConditionElsif   LParen Expression RParen Block
+ConditionElsifExpr          ::= ConditionElsif   LParen Expression RParen Block ConditionElsifExpr
+                              | ConditionElsif   LParen Expression RParen Block
 ConditionElseExpr           ::= ConditionElse    Block
 ConditionIfPostfixExpr      ::= ConditionIf      Expression
 ConditionUnlessPostfixExpr  ::= ConditionUnless  Expression

--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -19,6 +19,7 @@ Statement ::= NonBraceExpression StatementModifier
             | Block
             | Condition
             | EllipsisStatement
+            | QLikeExpression
 
 LoopStatement ::= ForStatement
                 | WhileStatement
@@ -328,11 +329,6 @@ OpKeyword ::= OpKeywordAbsExpr
             | OpKeywordPrintfExpr
             | OpKeywordPrototypeExpr
             | OpKeywordPushExpr
-            | OpKeywordQExpr
-            | OpKeywordQqExpr
-            | OpKeywordQxExpr
-            | OpKeywordQwExpr
-            | OpKeywordQrExpr
             | OpKeywordQuotemetaExpr
             | OpKeywordRandExpr
             | OpKeywordReadExpr
@@ -755,12 +751,6 @@ OpKeywordPrototypeExpr        ::= OpKeywordPrototype Expression
 
 OpKeywordPushExpr             ::= OpKeywordPush Expression OpComma Expression
 
-OpKeywordQExpr                ::= OpKeywordQ  QFuncDelimitedValue
-OpKeywordQqExpr               ::= OpKeywordQq QFuncDelimitedValue
-OpKeywordQxExpr               ::= OpKeywordQx QFuncDelimitedValue
-OpKeywordQwExpr               ::= OpKeywordQw QFuncDelimitedValue
-OpKeywordQrExpr               ::= OpKeywordQr QFuncDelimitedValue
-
 OpKeywordQuotemetaExpr        ::= OpKeywordQuotemeta Expression
                                 | OpKeywordQuotemeta
 
@@ -999,18 +989,26 @@ OpFileStartTimeExpr             ::= OpFileStartTime            Expression
 OpFileAccessTimeExpr            ::= OpFileAccessTime           Expression
 OpFileChangeTimeExpr            ::= OpFileChangeTime           Expression
 
-QFuncDelimitedValue ::= LParen       NonRParenOrEscapedParens_Many               RParen
-                      | LParen       RParen
-                      | LBrace       NonRBraceOrEscapedBraces_Many               RBrace
-                      | LBrace       RBrace
-                      | LAngle       NonRAngleOrEscapedAngles_Many               RAngle
-                      | LAngle       RAngle
-                      | LBracket     NonRBracketOrEscapedBrackets_Many           RBracket
-                      | LBracket     RBracket
-                      | ForwardSlash NonForwardSlashOrEscapedForwardSlashes_Many ForwardSlash
-                      | ForwardSlash ForwardSlash
-                      | ExclamPoint  NonExclamPointOrEscapedExclamPoints_Many    ExclamPoint
-                      | ExclamPoint  ExclamPoint
+QLikeExpression ::= QLikeExpressionExpr
+
+QLikeExpressionExpr ~ QLikeFunction '(' NonRParenOrEscapedParens_Many               ')'
+                    | QLikeFunction '{' NonRBraceOrEscapedBraces_Many               '}'
+                    | QLikeFunction '<' NonRAngleOrEscapedAngles_Many               '>'
+                    | QLikeFunction '[' NonRBracketOrEscapedBrackets_Many           ']'
+                    | QLikeFunction '/' NonForwardSlashOrEscapedForwardSlashes_Many '/'
+                    | QLikeFunction '!' NonExclamPointOrEscapedExclamPoints_Many    '!'
+                    | QLikeFunction '()'
+                    | QLikeFunction '{}'
+                    | QLikeFunction '<>'
+                    | QLikeFunction '[]'
+                    | QLikeFunction '//'
+                    | QLikeFunction '!!'
+
+QLikeFunction ~ OpKeywordQ
+              | OpKeywordQq
+              | OpKeywordQx
+              | OpKeywordQw
+              | OpKeywordQr
 
 ###
 
@@ -1033,8 +1031,8 @@ SingleQuote    ~ [']
 
 Colon        ~ ':'
 Semicolon    ~ ';'
-ForwardSlash ~ '/'
-ExclamPoint  ~ '!'
+#ForwardSlash ~ '/'
+#ExclamPoint  ~ '!'
 Escape       ~ '\'
 
 SigilScalar   ~ '$'
@@ -1050,46 +1048,46 @@ LBracket ~ '['
 RBracket ~ ']'
 LBrace   ~ '{'
 RBrace   ~ '}'
-LAngle   ~ '<'
-RAngle   ~ '>'
+#LAngle   ~ '<'
+#RAngle   ~ '>'
 
 NonRParenOrEscapedParens_Many ~ NonRParenOrEscapedParens+
 NonRParenOrEscapedParens      ~ EscapedParens | NonRParen
 EscapedParens                 ~ EscapedLParen | EscapedRParen
-EscapedLParen                 ~ '\\('
-EscapedRParen                 ~ '\\)'
+EscapedLParen                 ~ Escape [(]
+EscapedRParen                 ~ Escape [)]
 NonRParen                     ~ [^)]
 
 NonRBracketOrEscapedBrackets_Many ~ NonRBracketOrEscapedBrackets+
 NonRBracketOrEscapedBrackets      ~ EscapedBrackets | NonRBracket
 EscapedBrackets                   ~ EscapedLBracket | EscapedRBracket
-EscapedLBracket                   ~ '\\['
-EscapedRBracket                   ~ '\\]'
+EscapedLBracket                   ~ Escape [\[]
+EscapedRBracket                   ~ Escape [\]]
 NonRBracket                       ~ [^\]]
 
 NonRBraceOrEscapedBraces_Many ~ NonRBraceOrEscapedBraces+
 NonRBraceOrEscapedBraces      ~ EscapedBraces | NonRBrace
 EscapedBraces                 ~ EscapedLBrace | EscapedRBrace
-EscapedLBrace                 ~ '\\{'
-EscapedRBrace                 ~ '\\}'
+EscapedLBrace                 ~ Escape [\{]
+EscapedRBrace                 ~ Escape [\}]
 NonRBrace                     ~ [^\}]
 
 NonRAngleOrEscapedAngles_Many ~ NonRAngleOrEscapedAngles+
 NonRAngleOrEscapedAngles      ~ EscapedAngles | NonRAngle
 EscapedAngles                 ~ EscapedLAngle | EscapedRAngle
-EscapedLAngle                 ~ '\\<'
-EscapedRAngle                 ~ '\\>'
+EscapedLAngle                 ~ Escape [<]
+EscapedRAngle                 ~ Escape [>]
 NonRAngle                     ~ [^>]
 
 NonForwardSlashOrEscapedForwardSlashes_Many ~ NonForwardSlashOrEscapedForwardSlashes+
 NonForwardSlashOrEscapedForwardSlashes      ~ EscapedForwardSlash | NonForwardSlash
-EscapedForwardSlash                        ~ '\/'
-NonForwardSlash                            ~ [^\/]
+EscapedForwardSlash                         ~ Escape [/]
+NonForwardSlash                             ~ [^\/]
 
 NonExclamPointOrEscapedExclamPoints_Many ~ NonExclamPointOrEscapedExclamPoints+
 NonExclamPointOrEscapedExclamPoints      ~ EscapedExclamPoint | NonExclamPoint
-EscapedExclamPoint                        ~ '\\!'
-NonExclamPoint                            ~ [^\!]
+EscapedExclamPoint                       ~ Escape [!]
+NonExclamPoint                           ~ [^\!]
 
 Ellipsis ~ '...'
 

--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -13,8 +13,24 @@ StatementSeq ::= Statement
                | Statement Semicolon
                | Statement Semicolon StatementSeq
 
-Statement ::= NonBraceExpression
+Statement ::= NonBraceExpression ConditionIfPostfixExpr
+            | NonBraceExpression ConditionUnlessPostfixExpr
+            | NonBraceExpression
             | Block
+            | Condition
+
+Condition ::= ConditionIfExpr ConditionElsifExpr ConditionElseExpr
+            | ConditionIfExpr ConditionElseExpr
+            | ConditionIfExpr ConditionElsifExpr
+            | ConditionIfExpr
+            | ConditionUnlessExpr
+
+ConditionUnlessExpr        ::= ConditionUnless LParen Expression RParen Block
+ConditionIfExpr            ::= ConditionIf     LParen Expression RParen Block
+ConditionElsifExpr         ::= ConditionElsif  LParen Expression RParen Block
+ConditionElseExpr          ::= ConditionElse   Block
+ConditionIfPostfixExpr     ::= ConditionIf     Expression
+ConditionUnlessPostfixExpr ::= ConditionUnless Expression
 
 Label ::= IdentComp Colon
 
@@ -1233,6 +1249,11 @@ OpFileBinary                ~ '-B'
 OpFileStartTime             ~ '-M'
 OpFileAccessTime            ~ '-A'
 OpFileChangeTime            ~ '-C'
+
+ConditionIf     ~ 'if'
+ConditionElsif  ~ 'elsif'
+ConditionElse   ~ 'else'
+ConditionUnless ~ 'unless'
 
 # These are some parsing rules for the Expressions for them:
 # ----

--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -15,8 +15,16 @@ StatementSeq ::= Statement
 
 Statement ::= NonBraceExpression StatementModifier
             | NonBraceExpression
+            | ForStatement
             | Block
             | Condition
+
+ForStatement ::= ForStatementOp LParen Statement Semicolon Statement Semicolon Statement RParen Block
+               | ForStatementOp OpKeywordMy VarScalar LParen Expression RParen Block
+               | ForStatementOp VarScalar LParen Expression RParen Block
+
+ForStatementOp ::= OpKeywordFor
+                 | OpKeywordForeach
 
 StatementModifier ::= ConditionIfPostfixExpr
                     | ConditionUnlessPostfixExpr
@@ -1065,6 +1073,8 @@ OpKeywordExists           ~ 'exists'
 OpKeywordExit             ~ 'exit'
 OpKeywordExp              ~ 'exp'
 OpKeywordFc               ~ 'fc'
+OpKeywordFor              ~ 'for'
+OpKeywordForeach          ~ 'foreach'
 OpKeywordFcntl            ~ 'fcntl'
 OpKeywordFileno           ~ 'fileno'
 OpKeywordFlock            ~ 'flock'

--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -15,9 +15,13 @@ StatementSeq ::= Statement
 
 Statement ::= NonBraceExpression StatementModifier
             | NonBraceExpression
-            | ForStatement
+            | LoopStatement
             | Block
             | Condition
+
+LoopStatement ::= ForStatement
+                | WhileStatement
+                | UntilStatement
 
 ForStatement ::= ForStatementOp LParen Statement Semicolon Statement Semicolon Statement RParen Block
                | ForStatementOp OpKeywordMy VarScalar LParen Expression RParen Block
@@ -25,6 +29,9 @@ ForStatement ::= ForStatementOp LParen Statement Semicolon Statement Semicolon S
 
 ForStatementOp ::= OpKeywordFor
                  | OpKeywordForeach
+
+WhileStatement ::= ConditionWhile LParen Expression RParen Block
+UntilStatement ::= ConditionUntil LParen Expression RParen Block
 
 StatementModifier ::= ConditionIfPostfixExpr
                     | ConditionUnlessPostfixExpr

--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -816,7 +816,7 @@ OpKeywordSpliceExpr           ::= OpKeywordSplice Expression OpComma Expression 
 
 # TODO: OpKeywordSplitExpr ::= OpKeywordSplit
 
-OpKeywordSprintfExpr          ::= OpKeywordSprintf Expression OpComma Expression
+OpKeywordSprintfExpr          ::= OpKeywordSprintf Expression
 
 OpKeywordSqrtExpr             ::= OpKeywordSqrt Expression
                                 | OpKeywordSqrt

--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -18,6 +18,7 @@ Statement ::= NonBraceExpression StatementModifier
             | LoopStatement
             | Block
             | Condition
+            | EllipsisStatement
 
 LoopStatement ::= ForStatement
                 | WhileStatement
@@ -40,6 +41,8 @@ StatementModifier ::= ConditionIfPostfixExpr
                     | ConditionForPostfixExpr
                     | ConditionForeachPostfixExpr
                     | ConditionWhenPostfixExpr
+
+EllipsisStatement ::= Ellipsis
 
 Condition ::= ConditionIfExpr ConditionElsifExpr ConditionElseExpr
             | ConditionIfExpr ConditionElseExpr
@@ -1012,6 +1015,8 @@ LBracket ~ '['
 RBracket ~ ']'
 LBrace   ~ '{'
 RBrace   ~ '}'
+
+Ellipsis ~ '...'
 
 UnderscorePackage ~ '__PACKAGE__'
 UnderscoreFile    ~ '__FILE__'

--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -999,17 +999,17 @@ OpFileStartTimeExpr             ::= OpFileStartTime            Expression
 OpFileAccessTimeExpr            ::= OpFileAccessTime           Expression
 OpFileChangeTimeExpr            ::= OpFileChangeTime           Expression
 
-QFuncDelimitedValue ::= LParen       NonRParen       RParen
+QFuncDelimitedValue ::= LParen       NonRParenOrEscapedParens_Many               RParen
                       | LParen       RParen
-                      | LBrace       NonRBrace       RBrace
+                      | LBrace       NonRBraceOrEscapedBraces_Many               RBrace
                       | LBrace       RBrace
-                      | LAngle       NonRAngle       RAngle
+                      | LAngle       NonRAngleOrEscapedAngles_Many               RAngle
                       | LAngle       RAngle
-                      | LBracket     NonRBracket     RBracket
+                      | LBracket     NonRBracketOrEscapedBrackets_Many           RBracket
                       | LBracket     RBracket
-                      | ForwardSlash NonForwardSlash ForwardSlash
+                      | ForwardSlash NonForwardSlashOrEscapedForwardSlashes_Many ForwardSlash
                       | ForwardSlash ForwardSlash
-                      | ExclamPoint  NonExclamPoint  ExclamPoint
+                      | ExclamPoint  NonExclamPointOrEscapedExclamPoints_Many    ExclamPoint
                       | ExclamPoint  ExclamPoint
 
 ###
@@ -1044,12 +1044,43 @@ RBrace   ~ '}'
 LAngle   ~ '<'
 RAngle   ~ '>'
 
-NonRParen       ~ [^)]+
-NonRBracket     ~ [^\]]+
-NonRBrace       ~ [^\}]+
-NonRAngle       ~ [^>]+
-NonForwardSlash ~ [^\/]+
-NonExclamPoint  ~ [^\!]+
+NonRParenOrEscapedParens_Many ~ NonRParenOrEscapedParens+
+NonRParenOrEscapedParens      ~ EscapedParens | NonRParen
+EscapedParens                 ~ EscapedLParen | EscapedRParen
+EscapedLParen                 ~ '\\('
+EscapedRParen                 ~ '\\)'
+NonRParen                     ~ [^)]
+
+NonRBracketOrEscapedBrackets_Many ~ NonRBracketOrEscapedBrackets+
+NonRBracketOrEscapedBrackets      ~ EscapedBrackets | NonRBracket
+EscapedBrackets                   ~ EscapedLBracket | EscapedRBracket
+EscapedLBracket                   ~ '\\['
+EscapedRBracket                   ~ '\\]'
+NonRBracket                       ~ [^\]]
+
+NonRBraceOrEscapedBraces_Many ~ NonRBraceOrEscapedBraces+
+NonRBraceOrEscapedBraces      ~ EscapedBraces | NonRBrace
+EscapedBraces                 ~ EscapedLBrace | EscapedRBrace
+EscapedLBrace                 ~ '\\{'
+EscapedRBrace                 ~ '\\}'
+NonRBrace                     ~ [^\}]
+
+NonRAngleOrEscapedAngles_Many ~ NonRAngleOrEscapedAngles+
+NonRAngleOrEscapedAngles      ~ EscapedAngles | NonRAngle
+EscapedAngles                 ~ EscapedLAngle | EscapedRAngle
+EscapedLAngle                 ~ '\\<'
+EscapedRAngle                 ~ '\\>'
+NonRAngle                     ~ [^>]
+
+NonForwardSlashOrEscapedForwardSlashes_Many ~ NonForwardSlashOrEscapedForwardSlashes+
+NonForwardSlashOrEscapedForwardSlashes      ~ EscapedForwardSlash | NonForwardSlash
+EscapedForwardSlash                        ~ '\/'
+NonForwardSlash                            ~ [^\/]
+
+NonExclamPointOrEscapedExclamPoints_Many ~ NonExclamPointOrEscapedExclamPoints+
+NonExclamPointOrEscapedExclamPoints      ~ EscapedExclamPoint | NonExclamPoint
+EscapedExclamPoint                        ~ '\\!'
+NonExclamPoint                            ~ [^\!]
 
 Ellipsis ~ '...'
 

--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -189,10 +189,10 @@ LitArray       ::= LBracket Expression RBracket
 LitHash        ::= LBrace Expression RBrace
                  | LBrace RBrace
 
-LitString      ::= SingleQuote NonSingleQuote SingleQuote
+LitString      ::= SingleQuote NonSingleOrEscapedQuote_Many SingleQuote
                  | SingleQuote SingleQuote
 
-InterpolString ::= DoubleQuote NonDoubleQuote DoubleQuote
+InterpolString ::= DoubleQuote NonDoubleOrEscapedQuote_Many DoubleQuote
                  | DoubleQuote DoubleQuote
 
 ArrowRHS ::= ArrowDerefCall
@@ -1017,16 +1017,25 @@ QFuncDelimitedValue ::= LParen       NonRParenOrEscapedParens_Many              
 IdentComp  ~ [a-zA-Z_]+
 PackageSep ~ '::'
 
-LitNumber      ~ [0-9]+
-SingleQuote    ~ [']
+LitNumber ~ [0-9]+
+
+NonDoubleOrEscapedQuote_Many ~ NonDoubleOrEscapedQuote+
+NonDoubleOrEscapedQuote      ~ EscapedDoubleQuote | NonDoubleQuote
+EscapedDoubleQuote           ~ Escape ["]
+NonDoubleQuote               ~ [^"]
 DoubleQuote    ~ ["]
-NonDoubleQuote ~ [^"]+
-NonSingleQuote ~ [^']+
+
+NonSingleOrEscapedQuote_Many ~ NonSingleOrEscapedQuote+
+NonSingleOrEscapedQuote      ~ EscapedSingleQuote | NonSingleQuote
+EscapedSingleQuote           ~ Escape [']
+NonSingleQuote               ~ [^']
+SingleQuote    ~ [']
 
 Colon        ~ ':'
 Semicolon    ~ ';'
 ForwardSlash ~ '/'
 ExclamPoint  ~ '!'
+Escape       ~ '\'
 
 SigilScalar   ~ '$'
 SigilArray    ~ '@'

--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -176,6 +176,7 @@ OpKeyword ::= OpKeywordAbsExpr
             | OpKeywordDefinedExpr
             | OpKeywordDeleteExpr
             | OpKeywordDieExpr
+            | OpKeywordDoExpr
             | OpKeywordDumpExpr
             | OpKeywordEachExpr
             | OpKeywordEofExpr
@@ -225,15 +226,18 @@ OpKeyword ::= OpKeywordAbsExpr
             | OpKeywordEndnetentExpr
             | OpKeywordEndprotoentExpr
             | OpKeywordEndserventExpr
+            | OpKeywordExecExpr
             | OpKeywordGetsocknameExpr
             | OpKeywordGetsockoptExpr
             | OpKeywordGlobExpr
             | OpKeywordGmtimeExpr
             | OpKeywordGotoExpr
+            | OpKeywordGrepExpr
             | OpKeywordHexExpr
             | OpKeywordIndexExpr
             | OpKeywordIntExpr
             | OpKeywordIoctlExpr
+            | OpKeywordJoinExpr
             | OpKeywordKeysExpr
             | OpKeywordKillExpr
             | OpKeywordLastExpr
@@ -247,19 +251,26 @@ OpKeyword ::= OpKeywordAbsExpr
             | OpKeywordLockExpr
             | OpKeywordLogExpr
             | OpKeywordLstatExpr
+            | OpKeywordMapExpr
             | OpKeywordMkdirExpr
             | OpKeywordMsgctlExpr
             | OpKeywordMsggetExpr
             | OpKeywordMsgrcvExpr
             | OpKeywordMsgsndExpr
+            | OpKeywordMyExpr
             | OpKeywordNextExpr
             | OpKeywordOctExpr
+            | OpKeywordOpenExpr
             | OpKeywordOpendirExpr
             | OpKeywordOrdExpr
+            | OpKeywordOurExpr
             | OpKeywordPackExpr
             | OpKeywordPipeExpr
             | OpKeywordPopExpr
             | OpKeywordPosExpr
+            | OpKeywordPrintExpr
+            | OpKeywordPrintfExpr
+            | OpKeywordPrototypeExpr
             | OpKeywordPushExpr
             | OpKeywordQuotemetaExpr
             | OpKeywordRandExpr
@@ -278,6 +289,7 @@ OpKeyword ::= OpKeywordAbsExpr
             | OpKeywordRewinddirExpr
             | OpKeywordRindexExpr
             | OpKeywordRmdirExpr
+            | OpKeywordSayExpr
             | OpKeywordScalarExpr
             | OpKeywordSeekExpr
             | OpKeywordSeekdirExpr
@@ -300,9 +312,11 @@ OpKeyword ::= OpKeywordAbsExpr
             | OpKeywordSocketExpr
             | OpKeywordSocketpairExpr
             | OpKeywordSpliceExpr
+            | OpKeywordSprintfExpr
             | OpKeywordSqrtExpr
             | OpKeywordSrandExpr
             | OpKeywordStatExpr
+            | OpKeywordStateExpr
             | OpKeywordStudyExpr
             | OpKeywordSubstrExpr
             | OpKeywordSymlinkExpr
@@ -310,9 +324,11 @@ OpKeyword ::= OpKeywordAbsExpr
             | OpKeywordSysopenExpr
             | OpKeywordSysreadExpr
             | OpKeywordSysseekExpr
+            | OpKeywordSystemExpr
             | OpKeywordSyswriteExpr
             | OpKeywordTellExpr
             | OpKeywordTelldirExpr
+            | OpKeywordTieExpr
             | OpKeywordTiedExpr
             | OpKeywordTimeExpr
             | OpKeywordTimesExpr
@@ -335,27 +351,12 @@ OpKeyword ::= OpKeywordAbsExpr
             | OpKeywordWriteExpr
 
 # TODO: (Add the following above)
-#| OpKeywordExec
-#| OpKeywordGrepExpr
-#| OpKeywordJoinExpr
-#| OpKeywordMapExpr
-#| OpKeywordMyExpr
 #| OpKeywordNoExpr
-#| OpKeywordOpenExpr
-#| OpKeywordOurExpr
 #| OpKeywordPackageExpr
-#| OpKeywordPrintExpr
-#| OpKeywordPrintfExpr
-#| OpKeywordPrototypeExpr
 #| OpKeywordRequireExpr
-#| OpKeywordSayExpr
 #| OpKeywordSortExpr
 #| OpKeywordSplitExpr
-#| OpKeywordSprintfExpr
-#| OpKeywordStateExpr
 #| OpKeywordSubExpr
-#| OpKeywordSystemExpr
-#| OpKeywordTieExpr
 #| OpKeywordUseExpr
 
 OpFile ::= OpFileReadableEffectiveExpr
@@ -452,7 +453,7 @@ OpKeywordDeleteExpr           ::= OpKeywordDelete Expression
 OpKeywordDieExpr              ::= OpKeywordDie Expression
 
 OpKeywordDoExpr               ::= OpKeywordDo Block
-                                | OpKeywordDo Expression
+                                | OpKeywordDo NonBraceExpression
 
 OpKeywordDumpExpr             ::= OpKeywordDump Label
                                 | OpKeywordDump Expression
@@ -560,6 +561,9 @@ OpKeywordEndprotoentExpr      ::= OpKeywordEndprotoent
 
 OpKeywordEndserventExpr       ::= OpKeywordEndservent
 
+OpKeywordExecExpr             ::= OpKeywordExec Block Expression
+                                | OpKeywordExec NonBraceExpression
+
 OpKeywordGetsocknameExpr      ::= OpKeywordGetsockname Expression
 
 OpKeywordGetsockoptExpr       ::= OpKeywordGetsockopt Expression OpComma Expression OpComma Expression
@@ -574,6 +578,9 @@ OpKeywordGotoExpr             ::= OpKeywordGoto Label
                                 | OpKeywordGoto Expression
                                 | OpKeywordGoto SigilCode IdentComp
 
+OpKeywordGrepExpr             ::= OpKeywordGrep Block Expression
+                                | OpKeywordGrep NonBraceExpression OpComma Expression
+
 OpKeywordHexExpr              ::= OpKeywordHex Expression
                                 | OpKeywordHex
 
@@ -585,7 +592,7 @@ OpKeywordIntExpr              ::= OpKeywordInt Expression
 
 OpKeywordIoctlExpr            ::= OpKeywordIoctl Expression OpComma Expression OpComma Expression
 
-#TODO: OpKeywordJoinExpr ::=
+OpKeywordJoinExpr             ::= OpKeywordJoin Expression OpComma Expression
 
 OpKeywordKeysExpr             ::= OpKeywordKeys VarHash
                                 | OpKeywordKeys VarArray
@@ -624,7 +631,8 @@ OpKeywordLogExpr              ::= OpKeywordLog Expression
 OpKeywordLstatExpr            ::= OpKeywordLstat Expression
                                 | OpKeywordLstat
 
-#TODO: OpKeywordMapExpr ::= OpKeywordMap Expression
+OpKeywordMapExpr              ::= OpKeywordMap Block Expression
+                                | OpKeywordMap NonBraceExpression OpComma Expression
 
 OpKeywordMkdirExpr            ::= OpKeywordMkdir Expression OpComma Expression
                                 | OpKeywordMkdir Expression
@@ -638,7 +646,7 @@ OpKeywordMsgrcvExpr           ::= OpKeywordMsgrcv Expression OpComma Expression 
 
 OpKeywordMsgsndExpr           ::= OpKeywordMsgsnd Expression OpComma Expression OpComma Expression
 
-# TODO: OpKeywordMyExpr ::= OpKeywordMy Expression
+OpKeywordMyExpr               ::= OpKeywordMy Expression
 
 OpKeywordNextExpr             ::= OpKeywordNext Label
                                 | OpKeywordNext Expression
@@ -649,14 +657,15 @@ OpKeywordNextExpr             ::= OpKeywordNext Label
 OpKeywordOctExpr              ::= OpKeywordOct Expression
                                 | OpKeywordOct
 
-# TODO: OpKeywordOpenExpr ::= OpKeywordOpen
+OpKeywordOpenExpr             ::= OpKeywordOpen Expression OpComma Expression OpComma Expression OpComma Expression
+                                | OpKeywordOpen Expression OpComma Expression OpComma Expression
 
 OpKeywordOpendirExpr          ::= OpKeywordOpendir Expression OpComma Expression
 
 OpKeywordOrdExpr              ::= OpKeywordOrd Expression
                                 | OpKeywordOrd
 
-# TODO: OpKeywordOurExpr ::= OpKeywordOur Expression
+OpKeywordOurExpr              ::= OpKeywordOur Expression
 
 OpKeywordPackExpr             ::= OpKeywordPack Expression OpComma Expression
 
@@ -670,9 +679,18 @@ OpKeywordPopExpr              ::= OpKeywordPop Expression
 OpKeywordPosExpr              ::= OpKeywordPos Expression
                                 | OpKeywordPos
 
-# TODO: OpKeywordPrintExpr     ::= OpKeywordPrint Expression
-# TODO: OpKeywordPrintfExpr    ::= OpKeywordPrintf Expression
-# TODO: OpKeywordPrototypeExpr ::= OpKeywordPrototype Expression
+OpKeywordPrintExpr            ::= OpKeywordPrint Block Expression
+                                | OpKeywordPrint NonBraceExpression OpComma Expression
+                                | OpKeywordPrint NonBraceExpression
+                                | OpKeywordPrint Block
+                                | OpKeywordPrint
+
+OpKeywordPrintfExpr           ::= OpKeywordPrintf Block NonBraceExpression OpComma Expression
+                                | OpKeywordPrintf NonBraceExpression OpComma Expression
+                                | OpKeywordPrintf Block
+
+OpKeywordPrototypeExpr        ::= OpKeywordPrototype Expression
+                                | OpKeywordPrototype
 
 OpKeywordPushExpr             ::= OpKeywordPush Expression OpComma Expression
 
@@ -723,6 +741,12 @@ OpKeywordRindexExpr           ::= OpKeywordRindex Expression OpComma Expression 
 
 OpKeywordRmdirExpr            ::= OpKeywordRmdir Expression
                                 | OpKeywordRmdir
+
+OpKeywordSayExpr              ::= OpKeywordSay Block Expression
+                                | OpKeywordSay NonBraceExpression OpComma Expression
+                                | OpKeywordSay NonBraceExpression
+                                | OpKeywordSay Block
+                                | OpKeywordSay
 
 OpKeywordScalarExpr           ::= OpKeywordScalar Expression
 
@@ -778,7 +802,7 @@ OpKeywordSpliceExpr           ::= OpKeywordSplice Expression OpComma Expression 
 
 # TODO: OpKeywordSplitExpr ::= OpKeywordSplit
 
-# TODO: OpKeywordSprintfExpr ::= OpKeywordSprintf
+OpKeywordSprintfExpr          ::= OpKeywordSprintf Expression OpComma Expression
 
 OpKeywordSqrtExpr             ::= OpKeywordSqrt Expression
                                 | OpKeywordSqrt
@@ -789,7 +813,7 @@ OpKeywordSrandExpr            ::= OpKeywordSrand Expression
 OpKeywordStatExpr             ::= OpKeywordStat Expression
                                 | OpKeywordStat
 
-# TODO: OpKeywordStateExpr ::= OpKeywordState
+OpKeywordStateExpr            ::= OpKeywordState Expression
 
 OpKeywordStudyExpr            ::= OpKeywordStudy Expression
                                 | OpKeywordStudy
@@ -816,14 +840,15 @@ OpKeywordSyswriteExpr         ::= OpKeywordSyswrite Expression OpComma Expressio
                                 | OpKeywordSyswrite Expression OpComma Expression OpComma Expression
                                 | OpKeywordSyswrite Expression OpComma Expression
 
-# TODO: OpKeywordsystemExpr ::= OpKeywordsystem Expression
+OpKeywordSystemExpr           ::= OpKeywordSystem Block Expression
+                                | OpKeywordSystem NonBraceExpression
 
 OpKeywordTellExpr             ::= OpKeywordTell Expression
                                 | OpKeywordTell
 
 OpKeywordTelldirExpr          ::= OpKeywordTelldir Expression
 
-# TODO: OpKeywordTieExpr ::= OpKeywordTie Expression
+OpKeywordTieExpr              ::= OpKeywordTie Expression OpComma Expression OpComma Expression
 
 OpKeywordTiedExpr             ::= OpKeywordTied Expression
 
@@ -992,7 +1017,7 @@ OpKeywordEach             ~ 'each'
 OpKeywordEof              ~ 'eof'
 OpKeywordEval             ~ 'eval'
 OpKeywordEvalbytes        ~ 'evalbytes'
-# TODO: OpKeywordExec             ~ 'exec'
+OpKeywordExec             ~ 'exec'
 OpKeywordExists           ~ 'exists'
 OpKeywordExit             ~ 'exit'
 OpKeywordExp              ~ 'exp'
@@ -1042,12 +1067,12 @@ OpKeywordGetsockopt       ~ 'getsockopt'
 OpKeywordGlob             ~ 'glob'
 OpKeywordGmtime           ~ 'gmtime'
 OpKeywordGoto             ~ 'goto'
-# TODO: #OpKeywordGrep             ~ 'grep'
+OpKeywordGrep             ~ 'grep'
 OpKeywordHex              ~ 'hex'
 OpKeywordIndex            ~ 'index'
 OpKeywordInt              ~ 'int'
 OpKeywordIoctl            ~ 'ioctl'
-#TODO: OpKeywordJoin             ~ 'join'
+OpKeywordJoin             ~ 'join'
 OpKeywordKeys             ~ 'keys'
 OpKeywordKill             ~ 'kill'
 OpKeywordLast             ~ 'last'
@@ -1061,28 +1086,28 @@ OpKeywordLocaltime        ~ 'localtime'
 OpKeywordLock             ~ 'lock'
 OpKeywordLog              ~ 'log'
 OpKeywordLstat            ~ 'lstat'
-# TODO: OpKeywordMap              ~ 'map'
+OpKeywordMap              ~ 'map'
 OpKeywordMkdir            ~ 'mkdir'
 OpKeywordMsgctl           ~ 'msgctl'
 OpKeywordMsgget           ~ 'msgget'
 OpKeywordMsgrcv           ~ 'msgrcv'
 OpKeywordMsgsnd           ~ 'msgsnd'
-# TODO: OpKeywordMy               ~ 'my'
+OpKeywordMy               ~ 'my'
 OpKeywordNext             ~ 'next'
 # TODO: OpKeywordNo               ~ 'no'
 OpKeywordOct              ~ 'oct'
-# TODO: OpKeywordOpen             ~ 'open'
+OpKeywordOpen             ~ 'open'
 OpKeywordOpendir          ~ 'opendir'
 OpKeywordOrd              ~ 'ord'
-# TODO: OpKeywordOur              ~ 'our'
+OpKeywordOur              ~ 'our'
 OpKeywordPack             ~ 'pack'
 # TODO: OpKeywordPackage          ~ 'package'
 OpKeywordPipe             ~ 'pipe'
 OpKeywordPop              ~ 'pop'
 OpKeywordPos              ~ 'pos'
-# TODO: OpKeywordPrint            ~ 'print'
-# TODO: OpKeywordPrintf           ~ 'printf'
-# TODO: #OpKeywordPrototype        ~ 'prototype'
+OpKeywordPrint            ~ 'print'
+OpKeywordPrintf           ~ 'printf'
+OpKeywordPrototype        ~ 'prototype'
 OpKeywordPush             ~ 'push'
 OpKeywordQuotemeta        ~ 'quotemeta'
 OpKeywordRand             ~ 'rand'
@@ -1102,7 +1127,7 @@ OpKeywordReverse          ~ 'reverse'
 OpKeywordRewinddir        ~ 'rewinddir'
 OpKeywordRindex           ~ 'rindex'
 OpKeywordRmdir            ~ 'rmdir'
-# TODO: OpKeywordSay              ~ 'say'
+OpKeywordSay              ~ 'say'
 OpKeywordScalar           ~ 'scalar'
 OpKeywordSeek             ~ 'seek'
 OpKeywordSeekdir          ~ 'seekdir'
@@ -1127,11 +1152,11 @@ OpKeywordSocketpair       ~ 'socketpair'
 # TODO: OpKeywordSort             ~ 'sort'
 OpKeywordSplice           ~ 'splice'
 # TODO: OpKeywordSplit            ~ 'split'
-# TODO: OpKeywordSprintf          ~ 'sprintf'
+OpKeywordSprintf          ~ 'sprintf'
 OpKeywordSqrt             ~ 'sqrt'
 OpKeywordSrand            ~ 'srand'
 OpKeywordStat             ~ 'stat'
-# TODO: OpKeywordState            ~ 'state'
+OpKeywordState            ~ 'state'
 OpKeywordStudy            ~ 'study'
 # TODO: OpKeywordSub              ~ 'sub'
 OpKeywordSubstr           ~ 'substr'
@@ -1140,11 +1165,11 @@ OpKeywordSyscall          ~ 'syscall'
 OpKeywordSysopen          ~ 'sysopen'
 OpKeywordSysread          ~ 'sysread'
 OpKeywordSysseek          ~ 'sysseek'
-# TODO: OpKeywordSystem           ~ 'system'
+OpKeywordSystem           ~ 'system'
 OpKeywordSyswrite         ~ 'syswrite'
 OpKeywordTell             ~ 'tell'
 OpKeywordTelldir          ~ 'telldir'
-# TODO: OpKeywordTie              ~ 'tie'
+OpKeywordTie              ~ 'tie'
 OpKeywordTied             ~ 'tied'
 OpKeywordTime             ~ 'time'
 OpKeywordTimes            ~ 'times'

--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -116,7 +116,9 @@ SubCall ::= Ident CallArgs
 CallArgs ::= LParen Expression RParen
            | LParen RParen
 
-Block ::= LBrace StatementSeq RBrace
+
+Block ::= LBrace RBrace
+        | LBrace StatementSeq RBrace
 
 ArrayElem ::= LBracket Expression RBracket
 
@@ -135,9 +137,16 @@ Literal         ::= NonBraceLiteral
                   | LitHash
 
 LitArray       ::= LBracket Expression RBracket
+                 | LBracket RBracket
+
 LitHash        ::= LBrace Expression RBrace
+                 | LBrace RBrace
+
 LitString      ::= SingleQuote NonSingleQuote SingleQuote
+                 | SingleQuote SingleQuote
+
 InterpolString ::= DoubleQuote NonDoubleQuote DoubleQuote
+                 | DoubleQuote DoubleQuote
 
 ArrowRHS ::= ArrowDerefCall
            | ArrowMethodCall

--- a/marpa/t/expression-q-functions.t
+++ b/marpa/t/expression-q-functions.t
@@ -9,7 +9,6 @@ use Guacamole::Test;
 # here we're just testing the delimiters
 my @q_functions = ( 'q', 'qq', 'qw', 'qx', 'qr' );
 
-
 my @delimiters = (
     [ '(', ')' ], # q(...) | q()
     [ '{', '}' ], # q{...} | q{}
@@ -20,11 +19,17 @@ my @delimiters = (
 
 foreach my $function (@q_functions) {
     foreach my $delimiter_set (@delimiters) {
-        my $string = sprintf '%s%s$foo%s',
-                     $function,
-                     $delimiter_set->@*;
+        my $simple_string = sprintf '%s%s$foo%s',
+                            $function,
+                            $delimiter_set->@*;
 
-        parses($string);
+        parses($simple_string);
+
+        my $escaped_string = sprintf '%s%s \\%s $foo \\%s %s',
+                             $function,
+                             $delimiter_set->@[ 0, 0, 1, 1 ];
+
+        parses($escaped_string);
 
         # and one without delimiters
         my $emptystring = sprintf '%s%s%s', $function,

--- a/marpa/t/expression-q-functions.t
+++ b/marpa/t/expression-q-functions.t
@@ -2,6 +2,8 @@ use strict;
 use warnings;
 use experimental qw< postderef >;
 
+use Test::More;
+use Test::Fatal qw< exception >;
 use Guacamole::Test;
 
 # qw is using spaces in between - that's different
@@ -34,7 +36,17 @@ foreach my $function (@q_functions) {
         # and one without delimiters
         my $emptystring = sprintf '%s%s%s', $function,
                           $delimiter_set->@*;
+
         parses($emptystring);
+
+        my $bad_string = sprintf '%s %s%s', $function,
+                         $delimiter_set->@*;
+
+        like(
+            exception { parses($bad_string) },
+            qr/Error \s in \s SLIF \s parse/xms,
+            "Failed to parse: $bad_string",
+        );
     }
 }
 

--- a/marpa/t/expression-q-functions.t
+++ b/marpa/t/expression-q-functions.t
@@ -1,0 +1,36 @@
+use strict;
+use warnings;
+use experimental qw< postderef >;
+
+use Guacamole::Test;
+
+# qw is using spaces in between - that's different
+# qr can have regex modifiers - that's different
+# here we're just testing the delimiters
+my @q_functions = ( 'q', 'qq', 'qw', 'qx', 'qr' );
+
+
+my @delimiters = (
+    [ '(', ')' ], # q(...) | q()
+    [ '{', '}' ], # q{...} | q{}
+    [ '<', '>' ], # q<...> | q<>
+    [ '/', '/' ], # q/.../ | q//
+    [ '!', '!' ], # q!...! | q!!
+);
+
+foreach my $function (@q_functions) {
+    foreach my $delimiter_set (@delimiters) {
+        my $string = sprintf '%s%s$foo%s',
+                     $function,
+                     $delimiter_set->@*;
+
+        parses($string);
+
+        # and one without delimiters
+        my $emptystring = sprintf '%s%s%s', $function,
+                          $delimiter_set->@*;
+        parses($emptystring);
+    }
+}
+
+done_testing;

--- a/marpa/t/quotes.t
+++ b/marpa/t/quotes.t
@@ -1,0 +1,13 @@
+use strict;
+use warnings;
+use experimental qw< postderef >;
+
+use Guacamole::Test;
+
+parses(q{ "hello" });
+parses(q{ 'hello' });
+
+parses(q{ "hello world \" foo ' " });
+parses(q{ 'hello world \' foo " ' });
+
+done_testing();


### PR DESCRIPTION
[This includes the commits from #25 and needs to be rebased before it's merged.]

This supports the following:

* `q()`, `q{}`, `q<>`, `q//`, `q!!`
* `qq()`, `qq{}`, `qq<>`, `qq//`, `qq!!`
* `qw()`, `qw{}`, `qw<>`, `qw//`, `qw!!`
* `qx()`, `qx{}`, `qx<>`, `qx//`, `qx!!`
* `qr()`, `qr{}`, `qr<>`, `qr//`, `qr!!`

Issues to fix:

* [x] Ambiguity of: `q()`, `qq()`, `qw()`, `qx()`, `qr()`
* [x] Support delimiter escaping.

More comments:

* We do not support nested delimiters. `q( () )` should and will fail.
* `qw()` disregards spaces between elements. I would love to resolve it in the future.
* `qr()` has regex modifiers. Those aren't supported here at all.