### PR TITLE
Add require and remove support for SubCalls with q/qq/qw/qr/qx

### DIFF
--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -21,6 +21,7 @@ Statement ::= BlockLevelExpression StatementModifier
             | EllipsisStatement
             | UseStatement
             | NoStatement
+            | RequireStatement
 
 LoopStatement ::= ForStatement
                 | WhileStatement
@@ -70,6 +71,10 @@ NoStatement ::= OpKeywordNo Ident VersionExpr Expression
               | OpKeywordNo Ident Expression
               | OpKeywordNo VersionExpr
               | OpKeywordNo Ident
+
+RequireStatement ::= OpKeywordRequire VersionExpr
+                   | OpKeywordRequire Ident
+                   | OpKeywordRequire Expression
 
 Condition ::= ConditionIfExpr ConditionElsifExpr ConditionElseExpr
             | ConditionIfExpr ConditionElseExpr
@@ -244,7 +249,6 @@ ArrowIndirectCall ::= SigilScalar Ident CallArgs
 
 # TODO: (Add the following above)
 #| OpKeywordPackageExpr
-#| OpKeywordRequireExpr
 #| OpKeywordSplitExpr
 #| OpKeywordSubExpr
 
@@ -1268,7 +1272,7 @@ OpKeywordRecv             ~ 'recv'
 OpKeywordRedo             ~ 'redo'
 OpKeywordRef              ~ 'ref'
 OpKeywordRename           ~ 'rename'
-# TODO: OpKeywordRequire          ~ 'require'
+OpKeywordRequire          ~ 'require'
 OpKeywordReset            ~ 'reset'
 OpKeywordReturn           ~ 'return'
 OpKeywordReverse          ~ 'reverse'

--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -200,8 +200,11 @@ VarArrayTop ::= SigilArrayTop VarName
 VarName ::= Ident
           | VarScalar
 
-SubCall ::= Ident CallArgs
+SubCall ::= NonQLikeIdent CallArgs
           | VarCode CallArgs
+
+NonQLikeIdent ::= NonQLikeFunctionName
+                | NonQLikeFunctionName Ident
 
 CallArgs ::= ParenExpr
 
@@ -1000,6 +1003,17 @@ QLikeFunction ~ OpKeywordQ
               | OpKeywordQr
 
 ###
+
+NonQLikeFunctionName ::= NonQLetter
+                       | NonQLetter NonQLetter
+                       | NonQLetter NonWLetter
+                       | NonQLetter NonXLetter
+                       | NonQLetter NonRLetter
+
+NonQLetter ~ [a-pr-z]
+NonWLetter ~ [a-vx-z]
+NonRLetter ~ [a-qs-z]
+NonXLetter ~ [a-wy-z]
 
 IdentComp  ~ [a-zA-Z_]+
 PackageSep ~ '::'

--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -19,7 +19,6 @@ Statement ::= BlockLevelExpression StatementModifier
             | Block
             | Condition
             | EllipsisStatement
-            | QLikeExpression
             | UseStatement
             | NoStatement
 
@@ -151,10 +150,10 @@ BlockLevelExprNameAnd ::= BlockLevelExprNameAnd OpNameAnd ExprNameNot | BlockLev
 BlockLevelExprNameOr ::= BlockLevelExprNameOr OpNameOr ExprNameAnd | BlockLevelExprNameAnd action => ::first
 BlockLevelExpression ::= BlockLevelExprNameOr action => ::first
 
-Value         ::= Literal | NonLiteral
+Value         ::= Literal | NonLiteral | QLikeValue
 
 # Same as Value above, but with a NonBraceLiteral
-NonBraceValue ::= NonBraceLiteral | NonLiteral
+NonBraceValue ::= NonBraceLiteral | NonLiteral | QLikeValue
 
 NonLiteral ::= Variable action => ::first
              | Modifier Variable action => ::first
@@ -976,20 +975,20 @@ OpFile ::=
     | OpFileAccessTime
     | OpFileChangeTime
 
-QLikeExpression ::= QLikeExpressionExpr
+QLikeValue ::= QLikeValueExpr
 
-QLikeExpressionExpr ~ QLikeFunction '(' NonRParenOrEscapedParens_Many               ')'
-                    | QLikeFunction '{' NonRBraceOrEscapedBraces_Many               '}'
-                    | QLikeFunction '<' NonRAngleOrEscapedAngles_Many               '>'
-                    | QLikeFunction '[' NonRBracketOrEscapedBrackets_Many           ']'
-                    | QLikeFunction '/' NonForwardSlashOrEscapedForwardSlashes_Many '/'
-                    | QLikeFunction '!' NonExclamPointOrEscapedExclamPoints_Many    '!'
-                    | QLikeFunction '()'
-                    | QLikeFunction '{}'
-                    | QLikeFunction '<>'
-                    | QLikeFunction '[]'
-                    | QLikeFunction '//'
-                    | QLikeFunction '!!'
+QLikeValueExpr ~ QLikeFunction '(' NonRParenOrEscapedParens_Many               ')'
+               | QLikeFunction '{' NonRBraceOrEscapedBraces_Many               '}'
+               | QLikeFunction '<' NonRAngleOrEscapedAngles_Many               '>'
+               | QLikeFunction '[' NonRBracketOrEscapedBrackets_Many           ']'
+               | QLikeFunction '/' NonForwardSlashOrEscapedForwardSlashes_Many '/'
+               | QLikeFunction '!' NonExclamPointOrEscapedExclamPoints_Many    '!'
+               | QLikeFunction '()'
+               | QLikeFunction '{}'
+               | QLikeFunction '<>'
+               | QLikeFunction '[]'
+               | QLikeFunction '//'
+               | QLikeFunction '!!'
 
 QLikeFunction ~ OpKeywordQ
               | OpKeywordQq

--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -204,7 +204,6 @@ SubCall ::= Ident CallArgs
           | VarCode CallArgs
 
 CallArgs ::= ParenExpr
-           | LParen RParen
 
 Block ::= LBrace RBrace
         | LBrace StatementSeq RBrace

--- a/marpa/lib/Guacamole/Test.pm
+++ b/marpa/lib/Guacamole/Test.pm
@@ -12,11 +12,18 @@ use Guacamole::AST qw/cleanup/;
 use Exporter "import";
 
 our @EXPORT = qw(
+    parse_fail
     parses
     parses_as
     parsent
     done_testing
 );
+
+sub parse_fail {
+    my ($text) = @_;
+    local $Test::Builder::Level += 1;
+    Guacamole->parse($text);
+}
 
 sub parses {
     my ($text) = @_;

--- a/marpa/t/Statements/Expressions/qlike-functions.t
+++ b/marpa/t/Statements/Expressions/qlike-functions.t
@@ -21,31 +21,31 @@ my @delimiters = (
 
 foreach my $function (@q_functions) {
     foreach my $delimiter_set (@delimiters) {
-        my $simple_string = sprintf '%s%s$foo%s',
+        my $simple_string = sprintf 'say %s%s$foo%s',
                             $function,
                             $delimiter_set->@*;
 
         parses($simple_string);
 
-        my $escaped_string = sprintf '%s%s \\%s $foo \\%s %s',
+        my $escaped_string = sprintf 'say %s%s \\%s $foo \\%s %s',
                              $function,
                              $delimiter_set->@[ 0, 0, 1, 1 ];
 
         parses($escaped_string);
 
         # and one without delimiters
-        my $emptystring = sprintf '%s%s%s', $function,
+        my $emptystring = sprintf 'say %s%s%s', $function,
                           $delimiter_set->@*;
 
         parses($emptystring);
 
-        my $bad_string = sprintf '%s %s%s', $function,
+        my $bad_string = sprintf 'say %s %s%s', $function,
                          $delimiter_set->@*;
 
         like(
-            exception { parses($bad_string) },
+            exception( sub { parses($bad_string) } ),
             qr/Error \s in \s SLIF \s parse/xms,
-            "Failed to parse: $bad_string",
+            "Refuse to parse: $bad_string",
         );
     }
 }

--- a/marpa/t/Statements/Expressions/qlike-functions.t
+++ b/marpa/t/Statements/Expressions/qlike-functions.t
@@ -43,7 +43,7 @@ foreach my $function (@q_functions) {
                          $delimiter_set->@*;
 
         like(
-            exception( sub { parses($bad_string) } ),
+            exception( sub { parse_fail($bad_string) } ),
             qr/Error \s in \s SLIF \s parse/xms,
             "Refuse to parse: $bad_string",
         );

--- a/marpa/t/Statements/RequireStatement.t
+++ b/marpa/t/Statements/RequireStatement.t
@@ -1,0 +1,24 @@
+use strict;
+use warnings;
+
+use Guacamole::Test;
+
+parses(q{require v5.10.0});
+parses(q{require 5.010.000});
+
+parses(q{require Foo});
+parses(q{require Foo::Bar});
+
+parses(q{require "Foo.pm"});
+parses(q{require 'Foo.pm'});
+
+parses(q{require "Foo/Bar.pm"});
+parses(q{require 'Foo/Bar.pm'});
+
+parses(q{require qq<Foo.pm>});
+parses(q{require q<Foo.pm>});
+
+parses(q{require qq<Foo/Bar.pm>});
+parses(q{require q<Foo/Bar.pm>});
+
+done_testing();


### PR DESCRIPTION
* A bunch of tests
* Add the `require` keyword
* Finally make `q`/`qq`/`qw`/`qx`/`qr` *only* parsed once as the QLike functions and SubCalls explicitly cannot be named as such. (Not sure how I did it is good.)
* I removed an ambiguity with `ParenExpr`: We had `CallArgs` be either `ParenExpr` or `LParen RPaen`, but `ParenExpr` already includes the `LParen RParen`. This caused everything with `CallArgs` to be parsed ambiguously.