### PR TITLE
Subroutine support

### DIFF
--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -88,10 +88,13 @@ SubStatement ::= PhaseStatement Block
                | OpKeywordSub Ident SubDefinition
                | OpKeywordSub Ident
 
-SubDefinition ::= SubAttrsDefinition SubSigsDefinition Block
-                | SubAttrsDefinition Block
+SubDefinition ::= SubAttrsDefinitionSeq SubSigsDefinition Block
+                | SubAttrsDefinitionSeq Block
                 | SubSigsDefinition Block
-                |  Block
+                | Block
+
+SubAttrsDefinitionSeq ::= SubAttrsDefinition SubAttrsDefinitionSeq
+                        | SubAttrsDefinition
 
 SubAttrsDefinition ::= Colon IdentComp SubAttrArgs
                      | Colon IdentComp

--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -278,7 +278,6 @@ ArrowIndirectCall ::= SigilScalar Ident CallArgs
 
 # TODO: (Add the following above)
 #| OpKeywordSplitExpr
-#| OpKeywordSubExpr
 
 OpNullaryKeywordExpr ::=
       OpKeywordBreakExpr
@@ -300,6 +299,7 @@ OpNullaryKeywordExpr ::=
     | OpKeywordEndprotoentExpr
     | OpKeywordEndserventExpr
     | OpKeywordEvalExpr
+    | OpKeywordSubExpr
     | OpKeywordTimeExpr
     | OpKeywordTimesExpr
     | OpKeywordWaitExpr
@@ -903,7 +903,7 @@ OpKeywordStatExpr             ::= OpKeywordStat ExprKwUnary
 OpKeywordStudyExpr            ::= OpKeywordStudy ExprKwUnary
                                 | OpKeywordStudy
 
-# TODO: OpKeywordSubExpr ::= OpKeywordSub
+OpKeywordSubExpr              ::= OpKeywordSub SubDefinition
 
 OpKeywordSubstrExpr           ::= OpKeywordSubstr ExprKwList
 

--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -23,6 +23,7 @@ Statement ::= BlockLevelExpression StatementModifier
             | NoStatement
             | RequireStatement
             | PackageStatement
+            | SubStatement
 
 LoopStatement ::= ForStatement
                 | WhileStatement
@@ -81,6 +82,23 @@ PackageStatement ::= OpKeywordPackage Ident VersionExpr Block
                    | OpKeywordPackage Ident VersionExpr
                    | OpKeywordPackage Ident Block
                    | OpKeywordPackage Ident
+
+SubStatement ::= PhaseStatement Block
+               | OpKeywordSub PhaseStatement Block
+               | OpKeywordSub Ident SubDefinition
+               | OpKeywordSub Ident
+
+SubDefinition ::= SubAttrsDefinition SubSigsDefinition Block
+                | SubAttrsDefinition Block
+                | SubSigsDefinition Block
+                |  Block
+
+SubAttrsDefinition ::= Colon IdentComp SubAttrArgs
+                     | Colon IdentComp
+
+SubSigsDefinition  ::= LParen Expression RParen
+
+PhaseStatement ::= PhaseName
 
 Condition ::= ConditionIfExpr ConditionElsifExpr ConditionElseExpr
             | ConditionIfExpr ConditionElseExpr
@@ -1122,6 +1140,11 @@ UnderscoreSub     ~ '__SUB__'
 UnderscoreData    ~ '__DATA__'
 UnderscoreEnd     ~ '__END__'
 
+PhaseName ~ 'BEGIN' | 'CHECK' | 'INIT' | 'UNITCHECK' | 'END'
+
+SubAttrArgs ~ '(' NonRParenOrEscapedParens_Many ')'
+            | '(' ')'
+
 OpArrow   ~ '->'
 OpInc     ~ '++' | '--'
 OpPower   ~ '**'
@@ -1326,7 +1349,7 @@ OpKeywordSrand            ~ 'srand'
 OpKeywordStat             ~ 'stat'
 OpKeywordState            ~ 'state'
 OpKeywordStudy            ~ 'study'
-# TODO: OpKeywordSub              ~ 'sub'
+OpKeywordSub              ~ 'sub'
 OpKeywordSubstr           ~ 'substr'
 OpKeywordSymlink          ~ 'symlink'
 OpKeywordSyscall          ~ 'syscall'

--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -99,7 +99,7 @@ SubAttrsDefinitionSeq ::= SubAttrsDefinition SubAttrsDefinitionSeq
 SubAttrsDefinition ::= Colon IdentComp SubAttrArgs
                      | Colon IdentComp
 
-SubSigsDefinition  ::= LParen Expression RParen
+SubSigsDefinition ::= ParenExpr
 
 PhaseStatement ::= PhaseName
 

--- a/marpa/t/Statements/Expressions/OpKeywordExpr/sub.t
+++ b/marpa/t/Statements/Expressions/OpKeywordExpr/sub.t
@@ -1,0 +1,19 @@
+use strict;
+use warnings;
+use Guacamole::Test;
+
+parses('$cb = sub  () {1}');
+parses('$cb = sub  :attr {1}');
+parses('$cb = sub  : attr {1}');
+parses('$cb = sub  : attra :attrb {1}');
+parses('$cb = sub  :attr(foo) {1}');
+parses('$cb = sub  : attr(foo) {1}');
+parses('$cb = sub  ( $left, $right ) {1}');
+parses('$cb = sub  ($first, $bar, $third){1}');
+parses('$cb = sub  ($left, $right = 0) {1}');
+parses('$cb = sub  ($thing, $id = $auto_id++) {1}');
+parses('$cb = sub  :prototype($) {1}');
+parses('$cb = sub  :prototype($@\@) ($thing, $id = $auto_id++) {1}');
+parses('$cb = sub : const {$x}');
+
+done_testing();

--- a/marpa/t/Statements/PhaseStatements.t
+++ b/marpa/t/Statements/PhaseStatements.t
@@ -1,0 +1,17 @@
+use strict;
+use warnings;
+use Guacamole::Test;
+
+parses('BEGIN {1}');
+parses('CHECK {1}');
+parses('INIT {1}');
+parses('UNITCHECK {1}');
+parses('END {1}');
+
+parses('sub BEGIN {1}');
+parses('sub CHECK {1}');
+parses('sub INIT {1}');
+parses('sub UNITCHECK {1}');
+parses('sub END {1}');
+
+done_testing();

--- a/marpa/t/Statements/SubStatement.t
+++ b/marpa/t/Statements/SubStatement.t
@@ -1,0 +1,18 @@
+use strict;
+use warnings;
+use Guacamole::Test;
+
+parses('sub foo');
+parses('sub foo;');
+parses('sub foo :attr {1}');
+parses('sub foo : attr {1}');
+parses('sub foo :attr(foo) {1}');
+parses('sub foo : attr(foo) {1}');
+parses('sub foo ( $left, $right ) {1}');
+parses('sub foo ($first, $bar, $third){1}');
+parses('sub foo ($left, $right = 0) {1}');
+parses('sub foo ($thing, $id = $auto_id++) {1}');
+parses('sub foo :prototype($) {1}');
+parses('sub foo :prototype($@\@) ($thing, $id = $auto_id++) {1}');
+
+done_testing();

--- a/marpa/t/Statements/SubStatement.t
+++ b/marpa/t/Statements/SubStatement.t
@@ -4,6 +4,7 @@ use Guacamole::Test;
 
 parses('sub foo');
 parses('sub foo;');
+parses('sub foo () {1}');
 parses('sub foo :attr {1}');
 parses('sub foo : attr {1}');
 parses('sub foo : attra :attrb {1}');

--- a/marpa/t/Statements/SubStatement.t
+++ b/marpa/t/Statements/SubStatement.t
@@ -6,6 +6,7 @@ parses('sub foo');
 parses('sub foo;');
 parses('sub foo :attr {1}');
 parses('sub foo : attr {1}');
+parses('sub foo : attra :attrb {1}');
 parses('sub foo :attr(foo) {1}');
 parses('sub foo : attr(foo) {1}');
 parses('sub foo ( $left, $right ) {1}');


### PR DESCRIPTION
* Phases (`BEGIN`/`CHECK`/`INIT`/`UNITCHECK`/`END`) with and without `sub`
* Forward declarations: `sub foo;`
* Basic subroutines: `sub foo {...}`
* Basic sigs: `sub foo () {...}`
* Attributes: `sub foo :attr {...}`
* Multiple attributes: `sub foo :attr :anotherattr {...}`
* Complex sigs: `sub foo ( $arg1, @args ) {...}`
* Combination: `sub foo :prototype($@%) ( $arg1, @args ) {...}`
* Subroutines as expressions (callbacks) - same, but without a name