### PR TITLE
Support the rest of QLike ops, incuding all regular expression functions

### DIFF
--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -1088,64 +1088,24 @@ RegexModifiers ~ [a-z]*
 
 ###
 
-# -> (Plz to be done differently)
-# If it's a single letter, it can't be: m | q | s | y
-# If it's two letters, it can't be: tr | qq | qw | qx | qr
-# We also need to do the same for Phases (BEGIN | CHECK | INIT | UNITCHECK | END) 
+# NonQLikeFunction name is anything but:
+# q / qq / qw / qx / qr
+# s / m / tr / y
+# Subroutines are not allowed to be name as such
 
-NonQLikeFunctionName ::= SafeLetters
+NonQLikeFunctionName ::= NonQLikeLetters
                        | QLetter NonQRWXLetters
-                       | TLetter NonRLetters
-                       | UpBLetter NonUpELetters                              # <-- phases
-                       | UpBLetter UpELetter NonUpGLetters
-                       | UpBLetter UpELetter UpGLetter NonUpILetters
-                       | UpBLetter UpELetter UpGLetter UpILetter NonUpNLetters # Non-BEGIN
-                       | UpCLetter NonUpHLetters
-                       | UpCLetter UpHLetter NonUpELetters
-                       | UpCLetter UpHLetter UpELetter NonUpCLetters
-                       | UpCLetter UpHLetter UpELetter UpCLetter NonUpKLetters # Non-CHECK
-                       | UpELetter NonUpNLetters
-                       | UpELetter UpNLetter NonUpDLetters                     # Non-END
-                       | UpILetter NonUpNLetters
-                       | UpILetter UpNLetter NonUpILetters
-                       | UpILetter UpNLetter UpILetter NonUpTLetters           # Non-INIT
-                       | UpULetter NonUpNLetters
-                       | UpULetter UpNLetter NonUpILetters
-                       | UpULetter UpNLetter UpILetter NonUpTLetters
-                       | UpULetter UpNLetter UpILetter UpTLetter NonUpCLetters
-                       | UpULetter UpNLetter UpILetter UpTLetter UpCLetter NonUpHLetters
-                       | UpULetter UpNLetter UpILetter UpTLetter UpCLetter UpHLetter NonUpELetters
-                       | UpULetter UpNLetter UpILetter UpTLetter UpCLetter UpHLetter UpELetter NonUpCLetters
-                       | UpULetter UpNLetter UpILetter UpTLetter UpCLetter UpHLetter UpELetter UpCLetter NonUpKLetters # Non-CHECKUNIT
+                       | TLetter NonRLetter
 
-UpBLetter ~ 'B'
-UpCLetter ~ 'C'
-UpELetter ~ 'E'
-UpGLetter ~ 'G'
-UpHLetter ~ 'H'
-UpILetter ~ 'I'
-UpNLetter ~ 'N'
-UpTLetter ~ 'T'
-UpULetter ~ 'U'
+# QLike letters are: m / q / s / t / y
+NonQLikeLetters ~ [a-ln-pru-xzA-Z_]+
+QLetter         ~ 'q'
+TLetter         ~ 't'
+NonRLetter      ~ [a-qs-zA-Z_]+
+NonQRWXLetters  ~ [a-ps-vy-zA-Z_]+
 
-NonUpCLetters ~ [A-BD-Za-z_]
-NonUpDLetters ~ [A-CE-Za-z_]
-NonUpELetters ~ [A-DF-Za-z_]
-NonUpGLetters ~ [A-FH-Za-z_]
-NonUpHLetters ~ [A-GI-Za-z_]
-NonUpILetters ~ [A-HJ-Za-z_]
-NonUpKLetters ~ [A-JL-Za-z_]
-NonUpNLetters ~ [A-MO-Za-z_]
-NonUpTLetters ~ [A-SU-Za-z_]
 
-# This does not allow: m, q, s, t, y, B, C, E, I, U
-# That's because they stand for "m", "q*", "s", "tr", "y",
-# and "BEGIN", "UNIT", "END", "INIT", "UNITCHECK
-SafeLetters    ~ [a-ln-pru-xzADF-HJ-TV-Z_]
-QLetter        ~ 'q'
-TLetter        ~ 't'
-NonRLetters    ~ [a-qs-zA-Z_]
-NonQRWXLetters ~ [a-ps-vy-zA-Z_]
+
 
 IdentComp  ~ [a-zA-Z_]+
 PackageSep ~ '::'
@@ -1552,6 +1512,10 @@ whitespace ~ [\s]+
 <hash comment body>               ~ <hash comment char>*
 <vertical space char>             ~ [\x{A}\x{B}\x{C}\x{D}\x{2028}\x{2029}]
 <hash comment char>               ~ [^\x{A}\x{B}\x{C}\x{D}\x{2028}\x{2029}]
+
+:lexeme ~ PhaseName              priority => 1
+:lexeme ~ QLikeValueExpr         priority => 1
+:lexeme ~ QLikeValueExprWithMods priority => 1
 
 };
 

--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -85,8 +85,8 @@ PackageStatement ::= OpKeywordPackage Ident VersionExpr Block
 
 SubStatement ::= PhaseStatement Block
                | OpKeywordSub PhaseStatement Block
-               | OpKeywordSub Ident SubDefinition
-               | OpKeywordSub Ident
+               | OpKeywordSub NonQLikeIdent SubDefinition
+               | OpKeywordSub NonQLikeIdent
 
 SubDefinition ::= SubAttrsDefinitionSeq SubSigsDefinition Block
                 | SubAttrsDefinitionSeq Block
@@ -1088,18 +1088,64 @@ RegexModifiers ~ [a-z]*
 
 ###
 
+# -> (Plz to be done differently)
 # If it's a single letter, it can't be: m | q | s | y
 # If it's two letters, it can't be: tr | qq | qw | qx | qr
-# (Plz to be done differently)
-NonQLikeFunctionName ::= NonMQSTYLetters
-                       | QLetter NonQRWXLetter
-                       | TLetter NonRLetter
+# We also need to do the same for Phases (BEGIN | CHECK | INIT | UNITCHECK | END) 
 
-NonMQSTYLetters ~ [a-ln-pru-xzA-LN-PRU-XZ_]
-QLetter         ~ 'q'
-NonQRWXLetter   ~ [a-ps-vy-z_]
-TLetter         ~ 't'
-NonRLetter      ~ [a-qs-z_]
+NonQLikeFunctionName ::= SafeLetters
+                       | QLetter NonQRWXLetters
+                       | TLetter NonRLetters
+                       | UpBLetter NonUpELetters                              # <-- phases
+                       | UpBLetter UpELetter NonUpGLetters
+                       | UpBLetter UpELetter UpGLetter NonUpILetters
+                       | UpBLetter UpELetter UpGLetter UpILetter NonUpNLetters # Non-BEGIN
+                       | UpCLetter NonUpHLetters
+                       | UpCLetter UpHLetter NonUpELetters
+                       | UpCLetter UpHLetter UpELetter NonUpCLetters
+                       | UpCLetter UpHLetter UpELetter UpCLetter NonUpKLetters # Non-CHECK
+                       | UpELetter NonUpNLetters
+                       | UpELetter UpNLetter NonUpDLetters                     # Non-END
+                       | UpILetter NonUpNLetters
+                       | UpILetter UpNLetter NonUpILetters
+                       | UpILetter UpNLetter UpILetter NonUpTLetters           # Non-INIT
+                       | UpULetter NonUpNLetters
+                       | UpULetter UpNLetter NonUpILetters
+                       | UpULetter UpNLetter UpILetter NonUpTLetters
+                       | UpULetter UpNLetter UpILetter UpTLetter NonUpCLetters
+                       | UpULetter UpNLetter UpILetter UpTLetter UpCLetter NonUpHLetters
+                       | UpULetter UpNLetter UpILetter UpTLetter UpCLetter UpHLetter NonUpELetters
+                       | UpULetter UpNLetter UpILetter UpTLetter UpCLetter UpHLetter UpELetter NonUpCLetters
+                       | UpULetter UpNLetter UpILetter UpTLetter UpCLetter UpHLetter UpELetter UpCLetter NonUpKLetters # Non-CHECKUNIT
+
+UpBLetter ~ 'B'
+UpCLetter ~ 'C'
+UpELetter ~ 'E'
+UpGLetter ~ 'G'
+UpHLetter ~ 'H'
+UpILetter ~ 'I'
+UpNLetter ~ 'N'
+UpTLetter ~ 'T'
+UpULetter ~ 'U'
+
+NonUpCLetters ~ [A-BD-Za-z_]
+NonUpDLetters ~ [A-CE-Za-z_]
+NonUpELetters ~ [A-DF-Za-z_]
+NonUpGLetters ~ [A-FH-Za-z_]
+NonUpHLetters ~ [A-GI-Za-z_]
+NonUpILetters ~ [A-HJ-Za-z_]
+NonUpKLetters ~ [A-JL-Za-z_]
+NonUpNLetters ~ [A-MO-Za-z_]
+NonUpTLetters ~ [A-SU-Za-z_]
+
+# This does not allow: m, q, s, t, y, B, C, E, I, U
+# That's because they stand for "m", "q*", "s", "tr", "y",
+# and "BEGIN", "UNIT", "END", "INIT", "UNITCHECK
+SafeLetters    ~ [a-ln-pru-xzADF-HJ-TV-Z_]
+QLetter        ~ 'q'
+TLetter        ~ 't'
+NonRLetters    ~ [a-qs-zA-Z_]
+NonQRWXLetters ~ [a-ps-vy-zA-Z_]
 
 IdentComp  ~ [a-zA-Z_]+
 PackageSep ~ '::'

--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -1011,18 +1011,19 @@ OpFile ::=
 
 QLikeValue ::= QLikeValueExpr
 
-QLikeValueExpr ~ QLikeFunction '(' NonRParenOrEscapedParens_Many               ')'
-               | QLikeFunction '{' NonRBraceOrEscapedBraces_Many               '}'
-               | QLikeFunction '<' NonRAngleOrEscapedAngles_Many               '>'
-               | QLikeFunction '[' NonRBracketOrEscapedBrackets_Many           ']'
-               | QLikeFunction '/' NonForwardSlashOrEscapedForwardSlashes_Many '/'
-               | QLikeFunction '!' NonExclamPointOrEscapedExclamPoints_Many    '!'
-               | QLikeFunction '()'
-               | QLikeFunction '{}'
-               | QLikeFunction '<>'
-               | QLikeFunction '[]'
-               | QLikeFunction '//'
-               | QLikeFunction '!!'
+QLikeValueExpr
+    ~ QLikeFunction '(' NonRParenOrEscapedParens_Many               ')'
+    | QLikeFunction '{' NonRBraceOrEscapedBraces_Many               '}'
+    | QLikeFunction '<' NonRAngleOrEscapedAngles_Many               '>'
+    | QLikeFunction '[' NonRBracketOrEscapedBrackets_Many           ']'
+    | QLikeFunction '/' NonForwardSlashOrEscapedForwardSlashes_Many '/'
+    | QLikeFunction '!' NonExclamPointOrEscapedExclamPoints_Many    '!'
+    | QLikeFunction '()'
+    | QLikeFunction '{}'
+    | QLikeFunction '<>'
+    | QLikeFunction '[]'
+    | QLikeFunction '//'
+    | QLikeFunction '!!'
 
 QLikeFunction ~ OpKeywordQ
               | OpKeywordQq

--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -1009,7 +1009,7 @@ OpFile ::=
     | OpFileAccessTime
     | OpFileChangeTime
 
-QLikeValue ::= QLikeValueExpr
+QLikeValue ::= QLikeValueExpr | QLikeValueExprWithMods
 
 QLikeValueExpr
     ~ QLikeFunction '(' NonRParenOrEscapedParens_Many               ')'
@@ -1029,20 +1029,41 @@ QLikeFunction ~ OpKeywordQ
               | OpKeywordQq
               | OpKeywordQx
               | OpKeywordQw
-              | OpKeywordQr
+
+QLikeValueExprWithMods
+    ~ QLikeFunctionWithMods '(' NonRParenOrEscapedParens_Many               ')' RegexModifiers
+    | QLikeFunctionWithMods '{' NonRBraceOrEscapedBraces_Many               '}' RegexModifiers
+    | QLikeFunctionWithMods '<' NonRAngleOrEscapedAngles_Many               '>' RegexModifiers
+    | QLikeFunctionWithMods '[' NonRBracketOrEscapedBrackets_Many           ']' RegexModifiers
+    | QLikeFunctionWithMods '/' NonForwardSlashOrEscapedForwardSlashes_Many '/' RegexModifiers
+    | QLikeFunctionWithMods '!' NonExclamPointOrEscapedExclamPoints_Many    '!' RegexModifiers
+    | QLikeFunctionWithMods '()' RegexModifiers
+    | QLikeFunctionWithMods '{}' RegexModifiers
+    | QLikeFunctionWithMods '<>' RegexModifiers
+    | QLikeFunctionWithMods '[]' RegexModifiers
+    | QLikeFunctionWithMods '//' RegexModifiers
+    | QLikeFunctionWithMods '!!' RegexModifiers
+
+QLikeFunctionWithMods ~ OpKeywordQr
+                      | OpKeywordM
+
+RegexModifiers ~ [a-z]*
 
 ###
 
-NonQLikeFunctionName ::= NonQLetter
+# If it's a single letter, it can't be 'm' or 'q'
+# If it's two letters, it can't be 'qq', 'qw', 'qx', or 'qr'
+NonQLikeFunctionName ::= NonMOrQLetter
                        | NonQLetter NonQLetter
                        | NonQLetter NonWLetter
                        | NonQLetter NonXLetter
                        | NonQLetter NonRLetter
 
-NonQLetter ~ [a-pr-z]
-NonWLetter ~ [a-vx-z]
-NonRLetter ~ [a-qs-z]
-NonXLetter ~ [a-wy-z]
+NonMOrQLetter ~ [a-ln-pr-z]
+NonQLetter    ~ [a-pr-z]
+NonWLetter    ~ [a-vx-z]
+NonRLetter    ~ [a-qs-z]
+NonXLetter    ~ [a-wy-z]
 
 IdentComp  ~ [a-zA-Z_]+
 PackageSep ~ '::'
@@ -1280,6 +1301,7 @@ OpKeywordLocaltime        ~ 'localtime'
 OpKeywordLock             ~ 'lock'
 OpKeywordLog              ~ 'log'
 OpKeywordLstat            ~ 'lstat'
+OpKeywordM                ~ 'm'
 OpKeywordMap              ~ 'map'
 OpKeywordMkdir            ~ 'mkdir'
 OpKeywordMsgctl           ~ 'msgctl'

--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -1043,6 +1043,8 @@ QLikeValueExprWithMods
     | QLikeFunctionWithMods '[]' RegexModifiers
     | QLikeFunctionWithMods '//' RegexModifiers
     | QLikeFunctionWithMods '!!' RegexModifiers
+    | '/' NonForwardSlashOrEscapedForwardSlashes_Many '/' RegexModifiers
+    | '//' RegexModifiers
 
 QLikeFunctionWithMods ~ OpKeywordQr
                       | OpKeywordM

--- a/marpa/t/Statements/Expressions/Value/QLikeValue.t
+++ b/marpa/t/Statements/Expressions/Value/QLikeValue.t
@@ -56,4 +56,9 @@ foreach my $function (@q_functions) {
     }
 }
 
+parses('$foo =~ /foo/');
+parses('$foo =~ /foo/xms');
+parses('$foo =~ //');
+parses('$foo =~ //xms');
+
 done_testing;

--- a/marpa/t/Statements/Expressions/Value/QLikeValue.t
+++ b/marpa/t/Statements/Expressions/Value/QLikeValue.t
@@ -85,4 +85,7 @@ parses('$foo =~ s{foo}{}');
 parses('$foo =~ s{}{}');
 parses('$foo =~ s{}{}g');
 
+parses('`foo`');
+parses('``');
+
 done_testing;

--- a/marpa/t/Statements/Expressions/Value/QLikeValue.t
+++ b/marpa/t/Statements/Expressions/Value/QLikeValue.t
@@ -20,8 +20,8 @@ my @delimiters = (
 );
 
 foreach my $function (@q_functions) {
-    my $has_delimiters = $function eq 'm' || $function eq 'qr';
-    my $delimiters     = $has_delimiters ? 'xms' : '';
+    # This condition helps test with modifiers too
+    my $delimiters = ( $function eq 'm' || $function eq 'qr' ) ? 'xms' : '';
 
     foreach my $delimiter_set (@delimiters) {
         my $simple_string = sprintf 'say %s%s$foo%s%s',
@@ -48,6 +48,8 @@ foreach my $function (@q_functions) {
         my $bad_string = sprintf 'say %s %s%s', $function,
                          $delimiter_set->@[ 0, 1 ];
 
+        # q-like value with space will fail
+        # this includes s / m / y / tr
         like(
             exception( sub { parse_fail($bad_string) } ),
             qr/Error \s in \s SLIF \s parse/xms,

--- a/marpa/t/Statements/Expressions/Value/QLikeValue.t
+++ b/marpa/t/Statements/Expressions/Value/QLikeValue.t
@@ -61,4 +61,28 @@ parses('$foo =~ /foo/xms');
 parses('$foo =~ //');
 parses('$foo =~ //xms');
 
+# Should this work?
+#parses('
+#s {foo}  # Replace foo
+#  {bar}  # with bar.
+#');
+
+parses('$foo =~ /foo/');
+parses('$foo =~ /foo/xms');
+parses('$foo =~ //');
+parses('$foo =~ //xms');
+
+parses('tr/h-k/H-K/');
+parses('y/h-k/H-K/');
+parses('$foo =~ s/foo/bar/');
+parses('$foo =~ s/foo//');
+parses('$foo =~ s///');
+
+parses('tr{h-k}{H-K}');
+parses('y{h-k}{H-K}');
+parses('$foo =~ s{foo}{bar}');
+parses('$foo =~ s{foo}{}');
+parses('$foo =~ s{}{}');
+parses('$foo =~ s{}{}g');
+
 done_testing;

--- a/marpa/t/Statements/Expressions/Value/QLikeValue.t
+++ b/marpa/t/Statements/Expressions/Value/QLikeValue.t
@@ -9,7 +9,7 @@ use Guacamole::Test;
 # qw is using spaces in between - that's different
 # qr can have regex modifiers - that's different
 # here we're just testing the delimiters
-my @q_functions = ( 'q', 'qq', 'qw', 'qx', 'qr' );
+my @q_functions = ( 'q', 'qq', 'qw', 'qx', 'qr', 'm' );
 
 my @delimiters = (
     [ '(', ')' ], # q(...) | q()
@@ -20,27 +20,33 @@ my @delimiters = (
 );
 
 foreach my $function (@q_functions) {
+    my $has_delimiters = $function eq 'm' || $function eq 'qr';
+    my $delimiters     = $has_delimiters ? 'xms' : '';
+
     foreach my $delimiter_set (@delimiters) {
-        my $simple_string = sprintf 'say %s%s$foo%s',
+        my $simple_string = sprintf 'say %s%s$foo%s%s',
                             $function,
-                            $delimiter_set->@*;
+                            $delimiter_set->@[ 0, 1 ],
+                            $delimiters;
 
         parses($simple_string);
 
-        my $escaped_string = sprintf 'say %s%s \\%s $foo \\%s %s',
+        my $escaped_string = sprintf 'say %s%s \\%s $foo \\%s %s%s',
                              $function,
-                             $delimiter_set->@[ 0, 0, 1, 1 ];
+                             $delimiter_set->@[ 0, 0, 1, 1 ],
+                             $delimiters;
 
         parses($escaped_string);
 
         # and one without delimiters
-        my $emptystring = sprintf 'say %s%s%s', $function,
-                          $delimiter_set->@*;
+        my $emptystring = sprintf 'say %s%s%s%s', $function,
+                          $delimiter_set->@[ 0, 1 ],
+                          $delimiters;
 
         parses($emptystring);
 
         my $bad_string = sprintf 'say %s %s%s', $function,
-                         $delimiter_set->@*;
+                         $delimiter_set->@[ 0, 1 ];
 
         like(
             exception( sub { parse_fail($bad_string) } ),


### PR DESCRIPTION
This supports the following:

* `m//` - Similar to QLike functions but with modifiers (like `qr//`)
* `s///` - Similar to `m//` but has two arguments *and* modifiers
* `tr///` - Similar to `s///`
* `y///` - Similar to `y///`
* `qr{}`'s regex modifiers
* `//` - Similar to `m//` but without even a function name
* `` ` `` - Similar to `qx//` but without even a function name

* We separated what has modifiers, what doesn't.
* We don't allow subroutines that can be called `q`/`qq`/`qw`/`qx`/`qr`/`m`/`s`/`tr`/`y`.
* We also support delimiters that appear double (`s{}{}`).

However, because of how I implemented this, we don't support stuff like:

```perl
s {foo}   # Replace foo
  {bar};  # with bar.
```

If we want to support this, we'll need to do this across all QLike operators: `s///`, `y///`, `tr///`, `m//`, `qw//`, etc.

I don't think we should support that, to be honest, despite the convenience of putting regexes there.