### PR TITLE
Initial support for postderef

### DIFF
--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -283,12 +283,7 @@ ArrowDerefVariable ::= DerefVariableArgsAll
 ArrowMethodCall    ::= Ident CallArgs
 ArrowIndirectCall  ::= SigilScalar Ident CallArgs
 
-DerefVariableArgsAll ::= SigilScalar   SigilDerefAll
-                       | SigilArray    SigilDerefAll
-                       | SigilHash     SigilDerefAll
-                       | SigilCode     SigilDerefAll
-                       | SigilGlob     SigilDerefAll
-                       | SigilArrayTop
+DerefVariableArgsAll ::= '$*' | '@*' | '%*' | '&*' | '**' | SigilArrayTop
 
 DerefVariableSlice ::= '@[' Expression ']'
                      | '@{' Expression '}'
@@ -1171,7 +1166,6 @@ SigilHash     ~ '%'
 SigilCode     ~ '&'
 SigilGlob     ~ '*'
 SigilArrayTop ~ '$#'
-SigilDerefAll ~ '*'
 
 LParen   ~ '('
 RParen   ~ ')'

--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -290,10 +290,10 @@ DerefVariableArgsAll ::= SigilScalar   SigilDerefAll
                        | SigilGlob     SigilDerefAll
                        | SigilArrayTop
 
-DerefVariableSlice ::= SigilArray LitArray
-                     | SigilArray LitHash
-                     | SigilHash  LitArray
-                     | SigilHash  LitHash
+DerefVariableSlice ::= '@[' Expression ']'
+                     | '@{' Expression '}'
+                     | '%[' Expression ']'
+                     | '%{' Expression '}'
 
 # TODO: (Add the following above)
 #| OpKeywordSplitExpr

--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -272,13 +272,28 @@ InterpolString ::= DoubleQuote NonDoubleOrEscapedQuote_Many DoubleQuote
                  | DoubleQuote DoubleQuote
 
 ArrowRHS ::= ArrowDerefCall
+           | ArrowDerefVariable
            | ArrowMethodCall
            | ArrowIndirectCall
            | ElemSeq1
 
-ArrowDerefCall    ::= CallArgs
-ArrowMethodCall   ::= Ident CallArgs
-ArrowIndirectCall ::= SigilScalar Ident CallArgs
+ArrowDerefCall     ::= CallArgs
+ArrowDerefVariable ::= DerefVariableArgsAll
+                     | DerefVariableSlice
+ArrowMethodCall    ::= Ident CallArgs
+ArrowIndirectCall  ::= SigilScalar Ident CallArgs
+
+DerefVariableArgsAll ::= SigilScalar   SigilDerefAll
+                       | SigilArray    SigilDerefAll
+                       | SigilHash     SigilDerefAll
+                       | SigilCode     SigilDerefAll
+                       | SigilGlob     SigilDerefAll
+                       | SigilArrayTop
+
+DerefVariableSlice ::= SigilArray LitArray
+                     | SigilArray LitHash
+                     | SigilHash  LitArray
+                     | SigilHash  LitHash
 
 # TODO: (Add the following above)
 #| OpKeywordSplitExpr
@@ -1156,6 +1171,7 @@ SigilHash     ~ '%'
 SigilCode     ~ '&'
 SigilGlob     ~ '*'
 SigilArrayTop ~ '$#'
+SigilDerefAll ~ '*'
 
 LParen   ~ '('
 RParen   ~ ')'

--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -1108,14 +1108,11 @@ NonQLikeFunctionName ::= NonQLikeLetters
                        | TLetter NonRLetter
 
 # QLike letters are: m / q / s / t / y
-NonQLikeLetters ~ [a-ln-pru-xzA-Z_]+
+NonQLikeLetters ~ [a-ln-pru-xzA-Z_]
 QLetter         ~ 'q'
 TLetter         ~ 't'
-NonRLetter      ~ [a-qs-zA-Z_]+
-NonQRWXLetters  ~ [a-ps-vy-zA-Z_]+
-
-
-
+NonRLetter      ~ [a-qs-zA-Z_]
+NonQRWXLetters  ~ [a-ps-vy-zA-Z_]
 
 IdentComp  ~ [a-zA-Z_]+
 PackageSep ~ '::'

--- a/marpa/t/Statements/Expressions/Value/ArrowDerefVariable.t
+++ b/marpa/t/Statements/Expressions/Value/ArrowDerefVariable.t
@@ -1,0 +1,25 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Fatal qw< exception >;
+use Guacamole::Test;
+
+parses('$foo->$*');
+parses('$foo->@*');
+parses('$foo->%*');
+parses('$foo->&*');
+parses('$foo->**');
+parses('$foo->$#');
+
+parses('$foo->@[ 0, 3 ]');
+parses('$foo->%[ 0, 3 ]');
+
+parses('$foo->@{ 0, 3 }');
+parses('$foo->%{ 0, 3 }');
+
+ok(
+    exception( sub { parse_fail('$foo->% { "foo", "bar" }') } ),
+    'Failed to parse: $foo->% { "foo", "bar" }',
+);
+
+done_testing();

--- a/marpa/t/Statements/Expressions/Value/ArrowDerefVariable.t
+++ b/marpa/t/Statements/Expressions/Value/ArrowDerefVariable.t
@@ -4,18 +4,38 @@ use Test::More;
 use Test::Fatal qw< exception >;
 use Guacamole::Test;
 
-parses('$foo->$*');
-parses('$foo->@*');
-parses('$foo->%*');
-parses('$foo->&*');
-parses('$foo->**');
+foreach my $lead_sigil (qw< $ @ % & * >) {
+    parses( sprintf '$foo->%s*', $lead_sigil );
+    parse_fail( sprintf '$foo->%s *', $lead_sigil );
+
+}
+
 parses('$foo->$#');
 
-parses('$foo->@[ 0, 3 ]');
-parses('$foo->%[ 0, 3 ]');
+ok(
+    exception( sub { parse_fail('$foo->$ #') } ),
+    'Failed to parse: $foo->$ #',
+);
 
-parses('$foo->@{ 0, 3 }');
-parses('$foo->%{ 0, 3 }');
+foreach my $slice_sigil (qw< @ % >) {
+    parses("\$foo->$slice_sigil\[ 0, 3 \]");
+    parses("\$foo->$slice_sigil\{ 0, 3 \}");
+}
+
+ok(
+    exception( sub { parse_fail('$foo->@ [ "foo", "bar" ]') } ),
+    'Failed to parse: $foo->@ [ "foo", "bar" ]',
+);
+
+ok(
+    exception( sub { parse_fail('$foo->% [ "foo", "bar" ]') } ),
+    'Failed to parse: $foo->% [ "foo", "bar" ]',
+);
+
+ok(
+    exception( sub { parse_fail('$foo->@ { "foo", "bar" }') } ),
+    'Failed to parse: $foo->@ { "foo", "bar" }',
+);
 
 ok(
     exception( sub { parse_fail('$foo->% { "foo", "bar" }') } ),

--- a/marpa/t/Statements/Expressions/Value/ArrowDerefVariable.t
+++ b/marpa/t/Statements/Expressions/Value/ArrowDerefVariable.t
@@ -6,8 +6,13 @@ use Guacamole::Test;
 
 foreach my $lead_sigil (qw< $ @ % & * >) {
     parses( sprintf '$foo->%s*', $lead_sigil );
-    parse_fail( sprintf '$foo->%s *', $lead_sigil );
 
+    my $fail_str = sprintf '$foo->%s *', $lead_sigil;
+
+    ok(
+        exception( sub { parse_fail($fail_str) } ),
+        "Failed to parse: $fail_str",
+    );
 }
 
 parses('$foo->$#');


### PR DESCRIPTION
* `$foo->$*`
* `$foo->@*`
* `$foo->%*`
* `$foo->&*`
* `$foo->**`
* `$foo->$#`
* `$foo->@[...]`
* `$foo->@{...}`
* `$foo->%[...]`
* `$foo->%{...}`

A few problems:

* We don't identify by name `$*`, `@*`, `%*`, `&*`, etc.
* We don't identify by name `@[]`, `@{}`, `%[]`, `%{}`, etc.

A bug:

* perl does not support a space between chars when dereference:

```perl
# bug
$foo->@ [ 0, 1, ]
```

Unfortunately, we see this as legitimate.