### PR TITLE
Add array and hash element access

### DIFF
--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -187,13 +187,13 @@ Value         ::= Literal | NonLiteral | QLikeValue
 # Same as Value above, but with a NonBraceLiteral
 NonBraceValue ::= NonBraceLiteral | NonLiteral | QLikeValue
 
-NonLiteral ::= Variable action => ::first
-             | Modifier Variable action => ::first
-             | Modifier ParenExpr action => ::first
-             | UnderscoreValues action => ::first
-             | SubCall action => ::first
-             | ParenExpr action => ::first
-             | OpNullaryKeywordExpr action => ::first
+NonLiteral ::= Variable
+             | Modifier Variable
+             | Modifier ParenExpr
+             | UnderscoreValues
+             | SubCall
+             | ParenExpr
+             | OpNullaryKeywordExpr
 
 ParenExpr ::= LParen Expression RParen
             | LParen RParen # support ()

--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -192,13 +192,17 @@ NonLiteral ::= Variable
              | Modifier ParenExpr
              | UnderscoreValues
              | SubCall
-             | ParenExpr
+             | ParenExpr ElemSeq0
              | OpNullaryKeywordExpr
 
 ParenExpr ::= LParen Expression RParen
             | LParen RParen # support ()
 
 Modifier  ::= OpKeywordMy | OpKeywordOur | OpKeywordLocal | OpKeywordState
+
+ElemSeq0 ::= Element*
+ElemSeq1 ::= Element+
+Element  ::= ArrayElem | HashElem
 
 # UnderscoreData and UnderscoreEnd are not values
 UnderscoreValues ::= UnderscorePackage
@@ -218,9 +222,9 @@ Variable ::= VarScalar
            | VarGlob
            | VarArrayTop
 
-VarScalar   ::= SigilScalar VarName
-VarArray    ::= SigilArray VarName
-VarHash     ::= SigilHash VarName
+VarScalar   ::= SigilScalar VarName ElemSeq0
+VarArray    ::= SigilArray VarName ElemSeq0
+VarHash     ::= SigilHash VarName ElemSeq0
 VarCode     ::= SigilCode VarName
 VarGlob     ::= SigilGlob VarName
 VarArrayTop ::= SigilArrayTop VarName
@@ -270,8 +274,7 @@ InterpolString ::= DoubleQuote NonDoubleOrEscapedQuote_Many DoubleQuote
 ArrowRHS ::= ArrowDerefCall
            | ArrowMethodCall
            | ArrowIndirectCall
-           | ArrayElem
-           | HashElem
+           | ElemSeq1
 
 ArrowDerefCall    ::= CallArgs
 ArrowMethodCall   ::= Ident CallArgs

--- a/marpa/t/Statements/Expressions/arrow.t
+++ b/marpa/t/Statements/Expressions/arrow.t
@@ -8,5 +8,6 @@ parses('foo()->BAR::baz()');
 parses('foo()->$BAR::baz()');
 parses('foo()->[1]');
 parses('foo()->{1}');
+parses('foo()->[1]{2}');
 
 done_testing;

--- a/marpa/t/Statements/Expressions/variable.t
+++ b/marpa/t/Statements/Expressions/variable.t
@@ -21,4 +21,18 @@ parsent('$foo()');
 parses('&$foo()');
 parsent('$$foo()');
 
+parses('$foo[5]');
+parses('@foo[1, 2]');
+parses('%foo[1, 5]');
+parses('$foo[bar()]');
+parses('$foo["baz"]');
+parses('(stat $file)[2]');
+parses('$foo{1}');
+parses('$foo{1, 2}');
+parses('$foo{qw/foo bar/}');
+parses("stat[2]"); # stat anonarray
+
+parsent("5[1]");
+parsent('$x->y[1]');
+
 done_testing;


### PR DESCRIPTION
Fixes #42
    
Also add multi-deref option for the arrow operator: `->[1]{2}` is now accepted.
