### PR TITLE
Fix number parsing

### DIFF
--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -1234,15 +1234,12 @@ VersionNumberSegment ~ [0-9] [0-9] [0-9]
                      | [0-9] [0-9]
                      | [0-9]
 
-LitNumber ::= Negative Digits Period Digits
-            | Digits Period Digits
-            | Negative Digits
-            | Negative Infinite
-            | Infinite
-            | Digits
+LitNumber ::= LitNumberDec
+LitNumberDec ~ Digits Period Digits
+             | Digits Period
+             | Period Digits
+             | Digits
 
-Infinite    ~ 'Inf'
-Negative    ~ '-'
 Period      ~ '.'
 Digits      ~ [0-9]+
 SingleQuote ~ [']

--- a/marpa/t/Statements/Expressions/Value/Literal.t
+++ b/marpa/t/Statements/Expressions/Value/Literal.t
@@ -6,13 +6,9 @@ use Test::More;
 # LitNumber
 parses('4');
 parses('44');
-
-TODO: {
-    local $TODO = 'We still get confused between unary, concat, and numbers';
-    parses('-4');
-    parses('44.4');
-    parses('-44.4');
-}
+parses('-4');
+parses('44.4');
+parses('-44.4');
 
 # LitArray
 parses('[]');


### PR DESCRIPTION
Parse -4 as a `(unary - (litnumber 4))`
Disallow whitespace around dot by turning number into a single lexeme.
Remove bareword `Inf`, because it is not a valid number in perl.

Fixes #55.
Fixes #56.