### PR TITLE
$foo->$#* is correct, $foo->$# is not

### DIFF
--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -391,7 +391,7 @@ ArrowDerefVariable ::= DerefVariableArgsAll
 ArrowMethodCall    ::= Ident CallArgs
 ArrowIndirectCall  ::= SigilScalar Ident CallArgs
 
-DerefVariableArgsAll ::= '$*' | '@*' | '%*' | '&*' | '**' | SigilArrayTop
+DerefVariableArgsAll ::= '$*' | '@*' | '%*' | '&*' | '**' | '$#*'
 
 DerefVariableSlice ::= '@[' Expression ']'
                      | '@{' Expression '}'

--- a/marpa/t/Statements/Expressions/Value/ArrowDerefVariable.t
+++ b/marpa/t/Statements/Expressions/Value/ArrowDerefVariable.t
@@ -11,8 +11,9 @@ foreach my $lead_sigil (qw< $ @ % & * >) {
     parsent($fail_str);
 }
 
-parses('$foo->$#');
-parsent('$foo->$ #');
+parses('$foo->$#*');
+parsent('$foo->$#');
+parsent('$foo->$# *');
 
 foreach my $slice_sigil (qw< @ % >) {
     parses("\$foo->$slice_sigil\[ 0, 3 \]");


### PR DESCRIPTION
The tests that fail, fail because we don't return an error, just empty.

It's empty because we didn't catch all the types of things that didn't finish parsing when reporting.