### PR TITLE
Finally fix QLike values

### DIFF
--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -341,10 +341,33 @@ PackageArrow  ::= NonQLikeIdent OpArrow PackageArrowRHS
 PackageArrowRHS ::= ArrowMethodCall
                   | ArrowIndirectCall
 
-NonQLikeIdent ::= NonQLikeFunctionName
-                | NonQLikeFunctionName PackageSep
-                | NonQLikeFunctionName PackageSep Ident
-                | NonQLikeFunctionName Ident
+NonQLikeIdent ::= SubName
+                | SubName PackageSep Ident
+
+# This entire silly dance is done because:
+# 1. We define delimited values (q-like/s/m/tr/y) without spaces after delimiters
+# 2. Any of these can have parens as delimiters
+# 3. Thus, with a space and parens, it will be parsed as a function
+# So we must prevent "s ()" to exist as a subroutine name
+# --> If we remove the automatic ignoring of spaces, we won't need this
+SubName ::= LeadingSubLetter
+          | NonQLikeLetters AllSubLetters
+          | QLetter NonQRWXLetters
+          | QLetter NonQRWXLetters AllSubLetters
+          | QLetter QLetter AllSubLetters
+          | QLetter RLetter AllSubLetters
+          | QLetter WLetter AllSubLetters
+          | QLetter XLetter AllSubLetters
+          | SLetter AllSubLetters
+          | MLetter AllSubLetters
+          | TLetter NonRLetter
+          | TLetter NonRLetter AllSubLetters
+          | TLetter RLetter AllSubLetters
+          | YLetter AllSubLetters
+
+Ident ::= AllSubLetters
+        | AllSubLetters PackageSep
+        | AllSubLetters PackageSep Ident
 
 CallArgs ::= ParenExpr
 
@@ -354,10 +377,6 @@ Block ::= LBrace RBrace
 ArrayElem ::= LBracket Expression RBracket
 
 HashElem ::= LBrace Expression RBrace
-
-Ident ::= IdentComp
-        | IdentComp PackageSep Ident
-        | Ident PackageSep
 
 NonBraceLiteral ::= LitNumber
                   | LitArray
@@ -1207,19 +1226,21 @@ RegexModifiers ~ [a-z]*
 # q / qq / qw / qx / qr
 # s / m / tr / y
 # Subroutines are not allowed to be name as such
+NonQLikeLetters  ~ [a-ln-pru-xzA-Z_]
+LeadingSubLetter ~ [a-ln-prtu-xzA-Z_]
+AllSubLetters    ~ [a-zA-Z0-9_]+
+NonQRWXLetters   ~ [a-ps-vy-zA-Z0-9_]
+NonRLetter       ~ [a-qs-zA-Z0-9_]
+MLetter          ~ 'm'
+QLetter          ~ 'q'
+RLetter          ~ 'r'
+SLetter          ~ 's'
+TLetter          ~ 't'
+WLetter          ~ 'w'
+XLetter          ~ 'x'
+YLetter          ~ 'y'
 
-NonQLikeFunctionName ::= NonQLikeLetters
-                       | QLetter NonQRWXLetters
-                       | TLetter NonRLetter
-
-# QLike letters are: m / q / s / t / y
-NonQLikeLetters ~ [a-ln-pru-xzA-Z_]
-QLetter         ~ 'q'
-TLetter         ~ 't'
-NonRLetter      ~ [a-qs-zA-Z_]
-NonQRWXLetters  ~ [a-ps-vy-zA-Z_]
-
-IdentComp  ~ [a-zA-Z_]+
+IdentComp  ~ [a-zA-Z_0-9]+
 PackageSep ~ '::'
 
 VersionExpr           ::= VersionNumber

--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -1668,13 +1668,13 @@ sub parse {
     or do {
         my $err = $@;
         if (!@values) {
-            for my $nterm (reverse qw/Program Statement Expression SubCall Ident/) {
+            for my $nterm (reverse qw/Program BlockStatement Statement NonBraceExprComma BlockLevelExpression Expression SubCall Ident/) {
                 my ($start, $length) = $rec->last_completed($nterm);
                 next unless defined $start;
                 my $range = $rec->substring($start, $length);
                 my $expect = $rec->terminals_expected();
                 my $progress = $rec->show_progress();
-                die "$err\nFailed to parse past: $range (char $start, length $length), expected @$expect\n$progress";
+                die "$err\nFailed to parse past: $range (char $start, length $length), expected " . ( join ',', @{$expect} );# . "\n$progress";
             }
             die "Failed to parse, dunno why.";
         }

--- a/marpa/lib/Guacamole/Test.pm
+++ b/marpa/lib/Guacamole/Test.pm
@@ -63,7 +63,7 @@ sub parsent {
         1;
     };
     my $err = $@;
-    ok !defined $res && defined $err, "'$text': did not parse";
+    ok( !defined $res && defined $err, "'$text': did not parse" );
 
     foreach my $tree (@trees) {
         my $ast = cleanup($tree);

--- a/marpa/t/Statements/Expressions/Value/NonLiteral/SubCall.t
+++ b/marpa/t/Statements/Expressions/Value/NonLiteral/SubCall.t
@@ -5,10 +5,6 @@ use Test::More;
 
 parses('a()');
 parses('a::b()');
-
-TODO: {
-    local $TODO = 'We don\'t yet separate between Idents for SubCall and classes';
-    parsent('a::()');
-}
+parsent('a::()');
 
 done_testing();

--- a/marpa/t/Statements/Expressions/Value/QLikeValue.t
+++ b/marpa/t/Statements/Expressions/Value/QLikeValue.t
@@ -86,4 +86,23 @@ parses('$foo =~ s{}{}g');
 parses('`foo`');
 parses('``');
 
+# make sure we didn't screw up non q-like subroutine parsing
+parses('z()');
+parses('qz()');
+parses('qxx()');
+parses('qX()');
+parses('QX()');
+parses('Q()');
+parses('S()');
+parses('Sr()');
+parses('sr()');
+parses('M()');
+parses('mr()');
+parses('T()');
+parses('TR()');
+parses('Tr()');
+parses('tR()');
+parses('trz()');
+parses('rtz()'); # this somehow raised a bug, keeping it
+
 done_testing;

--- a/marpa/t/Statements/Expressions/Value/QLikeValue.t
+++ b/marpa/t/Statements/Expressions/Value/QLikeValue.t
@@ -87,22 +87,43 @@ parses('`foo`');
 parses('``');
 
 # make sure we didn't screw up non q-like subroutine parsing
-parses('z()');
-parses('qz()');
-parses('qxx()');
-parses('qX()');
-parses('QX()');
-parses('Q()');
-parses('S()');
-parses('Sr()');
-parses('sr()');
-parses('M()');
-parses('mr()');
-parses('T()');
-parses('TR()');
-parses('Tr()');
-parses('tR()');
+
+foreach my $func ( qw< q qq qw qx qr s m y tr > ) {
+    if ( length $func == 1 ) {
+        # single q-like letter
+        parses('z()');   # NonQLike single char
+        parses("${func}z()");  # NonQLike double char with leading q
+        parses("$func\_z()"); # NonQLike with underscore, leading q
+        parses("$func\_()");  # NonQLike with underscore, leading q
+        parses("_$func()");  # NonQLike with underscore, leading q
+        parses( uc($func) . '()');
+    }
+
+
+    if ( length $func == 2 ) {
+        my ( $letter1, $letter2 ) = split //xms, $func;
+        # double q-like letters
+        parses( sprintf '%s_()', $func );
+        parses( sprintf '%s_%s()', $letter1, $letter2 );
+        parses( sprintf '%s%s()', $func, $letter1 );
+        parses( sprintf '%s%s()', $func, $letter2 );
+        parses( sprintf '%sl()', $func );
+        parses( sprintf '%sl%s()', $letter1, $letter2 );
+        parses( sprintf '%s%s()', $letter1, uc $letter2 );
+        parses( sprintf '%s%s()',  uc $letter1, $letter2 );
+        parses( sprintf '%s()',  uc $func );
+    }
+}
+
+parses('t()');
+parses('r()');
+parses('x()');
+parses('w()');
+
+parsent('14()'); # Numbers cannot be subnames
+parsent('14_f()'); # Numbers cannot be subnames, even with underscores
+parsent('14f()'); # Numbers cannot be subnames, even with letters
 parses('trz()');
-parses('rtz()'); # this somehow raised a bug, keeping it
+parses('rtz()');
 
 done_testing;

--- a/marpa/t/Statements/Expressions/arrow.t
+++ b/marpa/t/Statements/Expressions/arrow.t
@@ -14,6 +14,6 @@ parses('$foo->thing()');
 parses('"Foo"->thing()');
 parses('Foo->thing()');
 
-parsent('Foo->thing');
+parsent('Foo->thing;');
 
 done_testing;

--- a/marpa/t/Statements/SubStatement.t
+++ b/marpa/t/Statements/SubStatement.t
@@ -19,4 +19,23 @@ parses('sub foo :prototype($@\@) ($thing, $id = $auto_id++) {1}');
 
 parses('Foo->method();');
 
+# make sure we didn't screw up non q-like subroutines
+parses('sub z {1}');
+parses('sub qz {1}');
+parses('sub qxx {1}');
+parses('sub qX {1}');
+parses('sub QX {1}');
+parses('sub Q {1}');
+parses('sub S {1}');
+parses('sub Sr {1}');
+parses('sub sr {1}');
+parses('sub M {1}');
+parses('sub mr {1}');
+parses('sub T {1}');
+parses('sub TR {1}');
+parses('sub Tr {1}');
+parses('sub tR {1}');
+parses('sub trz {1}');
+parses('sub rtz {1}'); # this somehow raised a bug, keeping it
+
 done_testing();

--- a/marpa/t/Statements/SubStatement.t
+++ b/marpa/t/Statements/SubStatement.t
@@ -20,22 +20,43 @@ parses('sub foo :prototype($@\@) ($thing, $id = $auto_id++) {1}');
 parses('Foo->method();');
 
 # make sure we didn't screw up non q-like subroutines
-parses('sub z {1}');
-parses('sub qz {1}');
-parses('sub qxx {1}');
-parses('sub qX {1}');
-parses('sub QX {1}');
-parses('sub Q {1}');
-parses('sub S {1}');
-parses('sub Sr {1}');
-parses('sub sr {1}');
-parses('sub M {1}');
-parses('sub mr {1}');
-parses('sub T {1}');
-parses('sub TR {1}');
-parses('sub Tr {1}');
-parses('sub tR {1}');
+
+foreach my $func ( qw< q qq qw qx qr s m y tr > ) {
+    if ( length $func == 1 ) {
+        # single q-like letter
+        parses('sub z {1}');   # NonQLike single char
+        parses("sub ${func}z {1}");  # NonQLike double char with leading q
+        parses("sub $func\_z {1}"); # NonQLike with underscore, leading q
+        parses("sub $func\_ {1}");  # NonQLike with underscore, leading q
+        parses("sub _$func {1}");  # NonQLike with underscore, leading q
+        parses( 'sub ' .  uc($func) . '{1}');
+    }
+
+
+    if ( length $func == 2 ) {
+        my ( $letter1, $letter2 ) = split //xms, $func;
+        # double q-like letters
+        parses( sprintf 'sub %s_ {1}', $func );
+        parses( sprintf 'sub %s_%s {1}', $letter1, $letter2 );
+        parses( sprintf 'sub %s%s {1}', $func, $letter1 );
+        parses( sprintf 'sub %s%s {1}', $func, $letter2 );
+        parses( sprintf 'sub %sl {1}', $func );
+        parses( sprintf 'sub %sl%s {1}', $letter1, $letter2 );
+        parses( sprintf 'sub %s%s {1}', $letter1, uc $letter2 );
+        parses( sprintf 'sub %s%s {1}',  uc $letter1, $letter2 );
+        parses( sprintf 'sub %s {1}',  uc $func );
+    }
+}
+
+parses('sub t {1}');
+parses('sub r {1}');
+parses('sub x {1}');
+parses('sub w {1}');
+
+parsent('sub 14 {1}'); # Numbers cannot be subnames
+parsent('sub 14_f {1}'); # Numbers cannot be subnames, even with underscores
+parsent('sub 14f {1}'); # Numbers cannot be subnames, even with letters
 parses('sub trz {1}');
-parses('sub rtz {1}'); # this somehow raised a bug, keeping it
+parses('sub rtz {1}');
 
 done_testing();

--- a/marpa/t/Statements/SubStatement.t
+++ b/marpa/t/Statements/SubStatement.t
@@ -19,6 +19,7 @@ parses('sub foo :prototype($@\@) ($thing, $id = $auto_id++) {1}');
 
 parses('Foo->method();');
 parsent('Foo::->method();');
+parsent('Foo->method;');
 
 # make sure we didn't screw up non q-like subroutines
 

--- a/marpa/t/Statements/SubStatement.t
+++ b/marpa/t/Statements/SubStatement.t
@@ -18,6 +18,7 @@ parses('sub foo :prototype($) {1}');
 parses('sub foo :prototype($@\@) ($thing, $id = $auto_id++) {1}');
 
 parses('Foo->method();');
+parsent('Foo::->method();');
 
 # make sure we didn't screw up non q-like subroutines
 


### PR DESCRIPTION
The combination of parens for non-spaced delimited values (like `q*`/`s`/`m`/`y`/`tr`) is causing them to be parsed as subroutines if they do have a space.

There is also a significant change as part of this (which has a test added to it):

```perl
Foo->method();        # Foo class
Foo::Bar->method();   # Foo::Bar class
Foo::Bar()->method(); # Foo class, Bar function in Foo class
Foo::Bar::->method(); # Fails <-- This is new!
Foo::Bar->method;     # Fails (don't know if it's new or not, but now there's a test!)
```

I added a bunch of tests and fixed the code.
