### PR TITLE
Prioritize VersionNumber when it can ambiguously be a LiteralNumber:

### DIFF
--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -1625,6 +1625,7 @@ whitespace ~ [\s]+
 :lexeme ~ PhaseName              priority => 1
 :lexeme ~ QLikeValueExpr         priority => 1
 :lexeme ~ QLikeValueExprWithMods priority => 1
+:lexeme ~ VersionNumber          priority => 1
 
 };
 


### PR DESCRIPTION
Since we started properly supported `LiteralNumbers`, `use Foo 4.1` can be confused as such instead of `VersionNumber`.