### PR TITLE
Support comma at end of ExprComma:

### DIFF
--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -201,8 +201,7 @@ ExprCondR     ::= ExprRange0  OpTriThen ExprRangeR OpTriElse ExprCondR | ExprRan
 ExprAssignL   ::= ExprCond0   OpAssign  ExprAssignL     | OpAssignKeywordExpr
                                                         | ExprCondL     action => ::first
 ExprAssignR   ::= ExprCond0   OpAssign  ExprAssignR     | ExprCondR     action => ::first
-ExprComma     ::= ExprAssignL OpComma   ExprComma
-                | ExprAssignL OpComma   ExprComma OpComma | ExprAssignR   action => ::first
+ExprComma     ::= ExprAssignL OpComma ExprComma | ExprAssignL OpComma | ExprAssignR action => ::first
 ExprNameNot   ::= OpNameNot   ExprNameNot               | ExprComma     action => ::first
 ExprNameAnd   ::= ExprNameAnd OpNameAnd ExprNameNot     | ExprNameNot   action => ::first
 ExprNameOr    ::= ExprNameOr  OpNameOr  ExprNameAnd     | ExprNameAnd   action => ::first

--- a/marpa/lib/Guacamole.pm
+++ b/marpa/lib/Guacamole.pm
@@ -201,7 +201,8 @@ ExprCondR     ::= ExprRange0  OpTriThen ExprRangeR OpTriElse ExprCondR | ExprRan
 ExprAssignL   ::= ExprCond0   OpAssign  ExprAssignL     | OpAssignKeywordExpr
                                                         | ExprCondL     action => ::first
 ExprAssignR   ::= ExprCond0   OpAssign  ExprAssignR     | ExprCondR     action => ::first
-ExprComma     ::= ExprAssignL OpComma   ExprComma       | ExprAssignR   action => ::first
+ExprComma     ::= ExprAssignL OpComma   ExprComma
+                | ExprAssignL OpComma   ExprComma OpComma | ExprAssignR   action => ::first
 ExprNameNot   ::= OpNameNot   ExprNameNot               | ExprComma     action => ::first
 ExprNameAnd   ::= ExprNameAnd OpNameAnd ExprNameNot     | ExprNameNot   action => ::first
 ExprNameOr    ::= ExprNameOr  OpNameOr  ExprNameAnd     | ExprNameAnd   action => ::first

--- a/marpa/t/Statements/Expressions/ExprComma.t
+++ b/marpa/t/Statements/Expressions/ExprComma.t
@@ -1,0 +1,10 @@
+use strict;
+use warnings;
+use Guacamole::Test;
+
+parses('$foo = { "a" => "b" }');
+parses('$foo = { "a" => "b", }');
+parses('$foo = [ 1, 2 ]');
+parses('$foo = [ 1, 2, ]');
+
+done_testing();

--- a/marpa/t/Statements/Expressions/ExprComma.t
+++ b/marpa/t/Statements/Expressions/ExprComma.t
@@ -6,5 +6,6 @@ parses('$foo = { "a" => "b" }');
 parses('$foo = { "a" => "b", }');
 parses('$foo = [ 1, 2 ]');
 parses('$foo = [ 1, 2, ]');
+parses('$foo = [ 1, ]');
 
 done_testing();


### PR DESCRIPTION
```perl
    %hash = (
        'a' => 'b',
        'b' => 'c',
    );

    @array = (
        foo(),
        bar(),
    );
```

Fixes #45.