### PR TITLE
Remove non-perl stuff:

### DIFF
--- a/marpa/lib/standard.pm
+++ b/marpa/lib/standard.pm
@@ -11,6 +11,12 @@ sub import ( $class ) {
     my $caller_file = $caller[1];
     my $content     = Path::Tiny::path($caller_file)->slurp_utf8();
 
+    # Filter out everything past __DATA__ or __END__
+    strip_terminators(\$content);
+
+    # Strip POD, it isn't Perl
+    strip_pods(\$content);
+
     eval { Guacamole->parse($content); }
     or do {
         print STDERR "File '$caller_file' does not pass Standard Perl.\n"
@@ -21,5 +27,31 @@ sub import ( $class ) {
     return;
 }
 
+sub strip_terminators ($contentref) {
+    ${$contentref} =~ s/^__DATA__\n.*//xms;
+    ${$contentref} =~ s/^__END__\n.*//xms;
+}
+
+sub strip_pods ($contentref) {
+    my @content_lines = split /\n/, ${$contentref};
+    my $in_pod;
+    foreach my $line (@content_lines) {
+        if ( $line =~ /^=(?!cut)/ ) {
+            $in_pod = 1;
+        }
+
+        $in_pod
+            or next;
+
+        $line =~ s{^}{#}xms;
+
+        # This is after replace, so it's already commented out
+        if ( $line =~ /^#=cut$/ ) {
+            $in_pod = 0;
+        }
+    }
+
+    ${$contentref} = join "\n", @content_lines;
+}
 
 1;


### PR DESCRIPTION
* We remove everything under `__END__` or `__DATA__`
* We comment out all POD (to not mess with line number)

The reasons are specified in GH #20 and GH #21.
This fixes GH #20.
This fixes GH #21.

I checked and it seems Marpa still reports the right line number and column for elements.