### PR TITLE
Fix handling of empty anonhash

### DIFF
--- a/marpa/t/Statements/Block.t
+++ b/marpa/t/Statements/Block.t
@@ -17,4 +17,6 @@ parses('{pop}');
 parses('{pop;}');
 parses('{a(); b();}');
 
+parsent('sort {} 1');
+
 done_testing;

--- a/marpa/t/Statements/Expressions/Value/Literal.t
+++ b/marpa/t/Statements/Expressions/Value/Literal.t
@@ -16,8 +16,13 @@ parses('[ 1, 2 ]');
 parses('[ 1, 2, ( 10, () ) ]');
 
 # LitHash
+parses('{}');
+parses('sub { {} }');
+parses('sort {}, 1');
 parses('$x = {}');
 parses('$x = { "foo" => "bar" }');
+parses('return { 1, 2, 3, 4 }');
+parsent('{ 1, 2, 3, 4 }');
 
 # LitString (SingleQuote)
 parses(q{''});


### PR DESCRIPTION
{} in block or expression context should be parsed as an empty hash
literal instead of a block.

LitHash and Block are split into empty and non-empty variants.

LitHashEmpty is added as a valid NonBraceLiteral, and corresponding
invocations of Block were replaced with BlockNonEmpty.