### PR TITLE
Fix parsing of $#_

### DIFF
--- a/lib/Guacamole.pm
+++ b/lib/Guacamole.pm
@@ -355,6 +355,7 @@ GlobalVarExpr ::= '$#'
                 | SigilArray  GlobalVariables ElemSeq0
                 | SigilHash   GlobalVariables ElemSeq0
                 | SigilGlob   GlobalVariables ElemSeq0
+                | SigilArrayTop GlobalVariables
 
 VarScalar   ::= SigilScalar VarIdentExpr ElemSeq0
 VarArray    ::= SigilArray VarIdentExpr ElemSeq0

--- a/t/Statements/Expressions/Value/NonLiteral/Variable.t
+++ b/t/Statements/Expressions/Value/NonLiteral/Variable.t
@@ -91,6 +91,7 @@ parses('$^X');
 parses('@+');
 parses('@-');
 parses('@_');
+parses('$#_');
 parses('@{^CAPTURE}');
 
 parses('%!');


### PR DESCRIPTION
Probably would be a good idea to do more specialized global (actually general) variables parsing.  In the current state it parses some non-existing things as correct ones.
I mean splitting general variables by type and defining matching valid sigils to each group.